### PR TITLE
Allow configuration of zk-hosts using env variable ZK_HOSTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ in the distribution zip file; you may modify settings after unzipping the file o
 
     kafka-manager.zkhosts="my.zookeeper.host.com:2181"
 
+Alternatively, use the environment variable `ZK_HOSTS` if you don't want to hardcode any values.
+
+    ZK_HOSTS="my.zookeeper.host.com:2181"
 
 Deployment
 ----------

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -61,6 +61,7 @@ logger.play=INFO
 logger.application=DEBUG
 
 kafka-manager.zkhosts="kafka-manager-zookeeper:2181"
+kafka-manager.zkhosts=${?ZK_HOSTS}
 pinned-dispatcher.type="PinnedDispatcher"
 pinned-dispatcher.executor="thread-pool-executor"
 


### PR DESCRIPTION
If set, `$ZK_HOSTS` will override the default value for `kafka-manager.zkhosts`.