### PR TITLE
Remove unnecessary zkHosts validation

### DIFF
--- a/app/kafka/manager/KafkaManagerActor.scala
+++ b/app/kafka/manager/KafkaManagerActor.scala
@@ -71,7 +71,6 @@ object ClusterConfig {
 
   def validateZkHosts(zkHosts: String): Unit = {
     require(zkHosts.length > 0, "cluster zk hosts is illegal, can't be empty!")
-    require(zkHosts.contains(":"), "cluster zk hosts is illegal, no port defined!")
   }
 
   def apply(name: String, version : String, zkHosts: String, zkMaxRetry: Int = 100) : ClusterConfig = {

--- a/test/kafka/manager/utils/TestClusterConfig.scala
+++ b/test/kafka/manager/utils/TestClusterConfig.scala
@@ -12,12 +12,6 @@ import org.scalatest.{Matchers, FunSuite}
  */
 class TestClusterConfig extends FunSuite with Matchers {
 
-  test("invalid zk hosts") {
-    intercept[IllegalArgumentException] {
-      ClusterConfig("qa","0.8.1.1","localhost")
-    }
-  }
-
   test("invalid name") {
     intercept[IllegalArgumentException] {
       ClusterConfig("qa!","0.8.1.1","localhost")


### PR DESCRIPTION
Curator assumes the default ZooKeeper port 2181 if none is specified, so
this validation check is unnecessary.