### PR TITLE
Update to Kafka 0.8.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Broker View
 Requirements
 ------------
 
-1. [Kafka 0.8.1.1 or 0.8.2-beta](http://kafka.apache.org/downloads.html)
+1. [Kafka 0.8.1.1 or 0.8.2.0](http://kafka.apache.org/downloads.html)
 2. [sbt 0.13.x](http://www.scala-sbt.org/download.html)
 3. Java 7+
 

--- a/app/kafka/manager/KafkaManagerActor.scala
+++ b/app/kafka/manager/KafkaManagerActor.scala
@@ -30,12 +30,12 @@ sealed trait KafkaVersion
 case object Kafka_0_8_1_1 extends KafkaVersion {
   override def toString = "0.8.1.1"
 }
-case object Kafka_0_8_2_beta extends KafkaVersion {
-  override def toString = "0.8.2-beta"
+case object Kafka_0_8_2_0 extends KafkaVersion {
+  override def toString = "0.8.2.0"
 }
 
 object KafkaVersion {
-  val supportedVersions: Map[String,KafkaVersion] = Map("0.8.1.1" -> Kafka_0_8_1_1, "0.8.2-beta" -> Kafka_0_8_2_beta)
+  val supportedVersions: Map[String,KafkaVersion] = Map("0.8.1.1" -> Kafka_0_8_1_1, "0.8.2.0" -> Kafka_0_8_2_0)
 
   val formSelectList : IndexedSeq[(String,String)] = supportedVersions.toIndexedSeq.map(t => (t._1,t._2.toString))
 

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-scalaz" % "3.2.11",
   "org.slf4j" % "log4j-over-slf4j" % "1.7.7",
   "com.adrianhurt" %% "play-bootstrap3" % "0.1.1",
-  "org.apache.kafka" %% "kafka" % "0.8.2-beta" % "test",
+  "org.apache.kafka" %% "kafka" % "0.8.2.0" % "test",
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
   "org.apache.curator" % "curator-test" % "2.7.0" % "test" force()
 )

--- a/test/kafka/manager/TestClusterManagerActor.scala
+++ b/test/kafka/manager/TestClusterManagerActor.scala
@@ -38,7 +38,7 @@ class TestClusterManagerActor extends CuratorAwareTest {
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
-    val clusterConfig = ClusterConfig("dev","0.8.2-beta",kafkaServerZkPath)
+    val clusterConfig = ClusterConfig("dev","0.8.2.0",kafkaServerZkPath)
     val curatorConfig = CuratorConfig(testServer.getConnectString)
     val config = ClusterManagerActorConfig("pinned-dispatcher","/kafka-manager/clusters/dev",curatorConfig,clusterConfig,FiniteDuration(1,SECONDS))
     val props = Props(classOf[ClusterManagerActor],config)

--- a/test/kafka/manager/TestKafkaManager.scala
+++ b/test/kafka/manager/TestKafkaManager.scala
@@ -207,7 +207,7 @@ class TestKafkaManager extends CuratorAwareTest {
   }
 
   test("update cluster version") {
-    val future = kafkaManager.updateCluster("dev","0.8.2-beta",testServer.getConnectString)
+    val future = kafkaManager.updateCluster("dev","0.8.2.0",testServer.getConnectString)
     val result = Await.result(future,duration)
     assert(result.isRight === true)
 

--- a/test/kafka/manager/TestKafkaManagerActor.scala
+++ b/test/kafka/manager/TestKafkaManagerActor.scala
@@ -106,7 +106,7 @@ class TestKafkaManagerActor extends CuratorAwareTest {
   }
 
   test("update cluster version") {
-    val cc2 = ClusterConfig("dev","0.8.2-beta",kafkaServerZkPath)
+    val cc2 = ClusterConfig("dev","0.8.2.0",kafkaServerZkPath)
     withKafkaManagerActor(KMUpdateCluster(cc2)) { result: KMCommandResult =>
       result.result.get
       Thread.sleep(3000)
@@ -133,7 +133,7 @@ class TestKafkaManagerActor extends CuratorAwareTest {
       println(result)
       result.msg.contains("dev")
     }
-    val cc2 = ClusterConfig("dev","0.8.2-beta",kafkaServerZkPath)
+    val cc2 = ClusterConfig("dev","0.8.2.0",kafkaServerZkPath)
     withKafkaManagerActor(KMAddCluster(cc2)) { result: KMCommandResult =>
       result.result.get
       Thread.sleep(1000)

--- a/test/kafka/manager/utils/TestClusterConfig.scala
+++ b/test/kafka/manager/utils/TestClusterConfig.scala
@@ -33,7 +33,7 @@ class TestClusterConfig extends FunSuite with Matchers {
   }
 
   test("serialize and deserialize") {
-    val cc = ClusterConfig("qa","0.8.2-beta","localhost:2181")
+    val cc = ClusterConfig("qa","0.8.2.0","localhost:2181")
     val serialize: String = ClusterConfig.serialize(cc)
     val deserialize = ClusterConfig.deserialize(serialize)
     assert(deserialize.isSuccess === true)
@@ -41,9 +41,9 @@ class TestClusterConfig extends FunSuite with Matchers {
   }
 
   test("deserialize without version") {
-    val cc = ClusterConfig("qa","0.8.2-beta","localhost:2181")
+    val cc = ClusterConfig("qa","0.8.2.0","localhost:2181")
     val serialize: String = ClusterConfig.serialize(cc)
-    val noverison = serialize.replace(""","kafkaVersion":"0.8.2-beta"""","")
+    val noverison = serialize.replace(""","kafkaVersion":"0.8.2.0"""","")
     assert(!noverison.contains("kafkaVersion"))
     val deserialize = ClusterConfig.deserialize(noverison)
     assert(deserialize.isSuccess === true)


### PR DESCRIPTION
Version 0.8.2.0 of Kafka is now available: https://archive.apache.org/dist/kafka/0.8.2.0/RELEASE_NOTES.html