### PR TITLE
Removed add clusters and modify cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,13 @@ dist
 activator*
 RUNNING_PID
 .DS_Store
+/bin
+.cache
+.classpath
+.project
+.sbtserver/
+.tmpBin
+project/.sbtserver
+project/.sbtserver.lock
+project/play-fork-run.sbt
+project/sbt-ui.sbt

--- a/app/GlobalKafkaManager.scala
+++ b/app/GlobalKafkaManager.scala
@@ -3,20 +3,25 @@
  * See accompanying LICENSE file.
  */
 
+import collection.JavaConversions._
 import controllers.KafkaManagerContext
 import kafka.manager.KafkaManager
 import play.api._
+import com.typesafe.config.ConfigException
+import models.navigation.BreadCrumbs
 
 /**
  * @author hiral
  */
-object GlobalKafkaManager extends GlobalSettings {
+object Global extends GlobalSettings {
 
   private[this] var kafkaManager: KafkaManager = null
+  val ClusterZks = "managed-kafka-clusters"
 
   override def beforeStart(app: Application): Unit = {
     Logger.info("Init kafka manager...")
-    KafkaManagerContext.getKafkaManger
+    kafkaManager = KafkaManagerContext.getKafkaManger
+    initialize_with_clusters_from_conf()
     Thread.sleep(5000)
   }
 
@@ -24,6 +29,38 @@ object GlobalKafkaManager extends GlobalSettings {
     KafkaManagerContext.shutdown()
     Logger.info("Application shutdown...")
   }
+  
+
+  def initialize_with_clusters_from_conf() {
+    Logger.info("initialize_with_clusters_from_conf(): Going to read kafka list from config and initialize")
+    
+    val configWithDefaults = kafkaManager.getConfigWithDefaults
+    
+    var member_zkhosts_list =  List[String]()
+    try {
+      member_zkhosts_list = configWithDefaults.getStringList(ClusterZks).toList
+    } catch {
+      case cfge: ConfigException => Logger.error("managed-kafka-clusters param not defined in the conf or is in wrong format")
+    }
+    
+    
+    member_zkhosts_list.foreach{ item => 
+      
+      // Each item in the list from config will be a string of format
+      // "clustername, version, zk1:port1, zk2:port2...."
+      //
+      val mylist = item.split(",")
+      val name = mylist(0)
+      val version = mylist(1)
+      val zkhosts = mylist.takeRight(mylist.size - 2).mkString(",")
+
+      
+      kafkaManager.addCluster(name, version, zkhosts)
+      
+    }
+  }
+  
+  
 }
 
 

--- a/app/kafka/manager/KafkaManager.scala
+++ b/app/kafka/manager/KafkaManager.scala
@@ -146,6 +146,8 @@ class KafkaManager(akkaConfig: Config) {
     }
   }
 
+  def getConfigWithDefaults = configWithDefaults
+  
   def addCluster(clusterName: String, version: String, zkHosts: String) : Future[ApiError \/ Unit] = {
     val cc = ClusterConfig(clusterName, version, zkHosts)
     tryWithKafkaManagerActor(KMAddCluster(cc)) { result: KMCommandResult =>

--- a/app/models/navigation/BreadCrumbs.scala
+++ b/app/models/navigation/BreadCrumbs.scala
@@ -27,8 +27,7 @@ object BreadCrumbs {
   import models.navigation.QuickRoutes._
 
   val baseBreadCrumbs: Map[String, IndexedSeq[BreadCrumb]] = Map(
-    "Clusters" -> IndexedSeq.empty[BreadCrumb],
-    "Add Cluster" -> IndexedSeq("Clusters".baseRouteBreadCrumb)
+    "Clusters" -> IndexedSeq.empty[BreadCrumb]
   )
 
   val clusterBreadCrumbs: Map[String, IndexedSeq[BreadCrumb]] = Map(

--- a/app/models/navigation/Menus.scala
+++ b/app/models/navigation/Menus.scala
@@ -13,8 +13,7 @@ object Menus {
   def clusterMenus(cluster: String) : IndexedSeq[Menu] = IndexedSeq(
     Menu("Cluster",IndexedSeq(
       "Summary".clusterRouteMenuItem(cluster),
-      "List".baseRouteMenuItem,
-      "Add Cluster".baseRouteMenuItem),
+      "List".baseRouteMenuItem),
       None),
     "Brokers".clusterMenu(cluster),
     Menu("Topic",IndexedSeq(
@@ -27,8 +26,7 @@ object Menus {
 
   def indexMenu : IndexedSeq[Menu] = IndexedSeq(
     Menu("Cluster",IndexedSeq(
-      "List".baseRouteMenuItem,
-      "Add Cluster".baseRouteMenuItem),
+      "List".baseRouteMenuItem),
       None)
   )
 }

--- a/app/models/navigation/QuickRoutes.scala
+++ b/app/models/navigation/QuickRoutes.scala
@@ -15,8 +15,7 @@ object QuickRoutes {
 
   val baseRoutes : Map[String, Call] = Map(
     "Clusters" -> controllers.routes.Application.index(),
-    "List" -> controllers.routes.Application.index(),
-    "Add Cluster" -> controllers.routes.Cluster.addCluster()
+    "List" -> controllers.routes.Application.index()
   )
   val clusterRoutes : Map[String, String => Call] = Map(
     "Update Cluster" -> controllers.routes.Cluster.updateCluster,

--- a/app/views/cluster/clusterList.scala.html
+++ b/app/views/cluster/clusterList.scala.html
@@ -23,7 +23,6 @@
                     <td>
                         <div class="btn-group-horizontal" role="group" aria-label="...">
                         @if(cluster.enabled) {
-                            <a href="@routes.Cluster.updateCluster(cluster.name)" class="btn btn-default ops-button" role="button">Modify</a>
                             @b3.form(routes.Cluster.handleUpdateCluster(cluster.name)) {
                             <input type="hidden" name="name" value="@cluster.name">
                             <input type="hidden" name="kafkaVersion" value="@cluster.version.toString">
@@ -38,13 +37,6 @@
                             <input type="hidden" name="zkHosts" value="@cluster.curatorConfig.zkConnect">
                             <input type="hidden" name="operation" value="Enable">
                             @b3.submit('class -> "btn btn-success ops-button"){ Enable }
-                            }
-                            @b3.form(routes.Cluster.handleUpdateCluster(cluster.name)) {
-                            <input type="hidden" name="name" value="@cluster.name">
-                            <input type="hidden" name="kafkaVersion" value="@cluster.version.toString">
-                            <input type="hidden" name="zkHosts" value="@cluster.curatorConfig.zkConnect">
-                            <input type="hidden" name="operation" value="Delete">
-                            @b3.submit('class -> "btn btn-danger ops-button"){ Delete }
                             }
                         }
                         </div>

--- a/build.sbt
+++ b/build.sbt
@@ -82,3 +82,6 @@ rpmLicense := Some("Apache")
 
 
 
+
+
+fork in run := true

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -65,3 +65,9 @@ kafka-manager.zkhosts=${?ZK_HOSTS}
 pinned-dispatcher.type="PinnedDispatcher"
 pinned-dispatcher.executor="thread-pool-executor"
 
+# These will be added into Kafka Manager at startup 
+# Value of this param is a list of strings representing info about kafka clusters to be managed
+#    ["clusterNmae, Version, zk1:port1, zk2:port2,...", ...]
+# Supported versions currently are "0.8.1.1"  and "0.8.2-beta"  only
+# (line 38:  kafka/manager/KafkaManagerActor.scala)
+managed-kafka-clusters=["kmgr1,0.8.2-beta,zk1:2181,zk2:2181"]


### PR DESCRIPTION
This pull request resolves #37 .

- Add cluster operation removed
- Modify cluster operation removed (since it allows to specify a list of ZK hosts, which allows a user to change and point to an entirely different Kafka cluster that he/she not supposed to manage)
- Left enable/disable operation as it is harmless

- Introduced config param to prime the Kafka Manager
 managed-kafka-clusters=["kmgr1,0.8.2-beta,zk1:2181,zk2:2181", "kmgr2,0.8.1.1,zk3:2181,zk4:2181"]