### PR TITLE
Fix class name type TopicListWithMoreInfo -> TopicListExtended

### DIFF
--- a/app/views/topic/topicList.scala.html
+++ b/app/views/topic/topicList.scala.html
@@ -3,7 +3,7 @@
 * See accompanying LICENSE file.
 *@
 @import scalaz.{\/}
-@(cluster:String, errorOrTopics: kafka.manager.ApiError \/ kafka.manager.TopicListWithMoreInfo)
+@(cluster:String, errorOrTopics: kafka.manager.ApiError \/ kafka.manager.TopicListExtended)
 
 @theMenu = {
     @views.html.navigation.clusterMenu(cluster,"Topic","List",models.navigation.Menus.clusterMenus(cluster))


### PR DESCRIPTION
It wont compile, the error was:

/app/views/topic/topicList.scala.html:6: type TopicListWithMoreInfo is not a member of package kafka.manager

after checkingout, there is no such class, the expected class is TopicListExtended, and it compiles and works great this way. thanks.