### PR TITLE
fix compile error

### DIFF
--- a/test/kafka/manager/TestKafkaManager.scala
+++ b/test/kafka/manager/TestKafkaManager.scala
@@ -91,7 +91,7 @@ class TestKafkaManager extends CuratorAwareTest {
     val future = kafkaManager.getBrokerList("dev")
     val result = Await.result(future,duration)
     assert(result.isRight === true)
-    assert(result.toOption.get.nonEmpty === true)
+    assert(result.toOption.get.list.nonEmpty === true)
   }
 
   test("get topic identity") {


### PR DESCRIPTION
```
kafka-manager/test/kafka/manager/TestKafkaManager.scala:94: value nonEmpty is not a member of kafka.manager.BrokerListExtended
[error]     assert(result.toOption.get.nonEmpty === true)
[error]                                ^
[error] one error found
```