### PR TITLE
Fixed logging of errors in BrokerViewCacheActor

### DIFF
--- a/app/kafka/manager/BrokerViewCacheActor.scala
+++ b/app/kafka/manager/BrokerViewCacheActor.scala
@@ -174,7 +174,7 @@ class BrokerViewCacheActor(config: BrokerViewCacheActorConfig) extends LongRunni
                     }
                     val result = tryResult match {
                       case scala.util.Failure(t) =>
-                        log.error(s"Failed to get topic metrics for broker $broker", t)
+                        log.error(t, s"Failed to get topic metrics for broker $broker")
                         topicPartitions.map {
                           case (topic, id, partitions) =>
                             (topic.topic, BrokerMetrics.DEFAULT)
@@ -198,7 +198,7 @@ class BrokerViewCacheActor(config: BrokerViewCacheActorConfig) extends LongRunni
 
                 val result = tryResult match {
                   case scala.util.Failure(t) =>
-                    log.error(s"Failed to get broker metrics for $broker", t)
+                    log.error(t, s"Failed to get broker metrics for $broker")
                     BrokerMetrics.DEFAULT
                   case scala.util.Success(bm) => bm
                 }

--- a/test/controller/api/TestKafkaHealthCheck.scala
+++ b/test/controller/api/TestKafkaHealthCheck.scala
@@ -50,12 +50,15 @@ class TestKafkaHealthCheck extends CuratorAwareTest with KafkaServerInTest {
 
   private[this] def createCluster() = {
     val future = KafkaManagerContext.getKafkaManager.addCluster(testClusterName,"0.8.2.0",kafkaServerZkPath, jmxEnabled = false)
-    Await.result(future,duration)
+    val result = Await.result(future,duration)
+    result.toEither.left.foreach(apiError => sys.error(apiError.msg))
+    Thread.sleep(3000)
   }
 
   private[this] def createTopic() = {
     val future = KafkaManagerContext.getKafkaManager.createTopic(testClusterName,testTopicName,4,1)
-    Await.result(future,duration)
+    val result = Await.result(future,duration)
+    result.toEither.left.foreach(apiError => sys.error(apiError.msg))
   }
 
   private[this] def deleteTopic() = {


### PR DESCRIPTION
Throwable cause instead of being passed as template argument, should be passed as first argument to log.error calls (see http://doc.akka.io/api/akka/current/index.html#akka.event.LoggingAdapter )
This bug is causing warnings like https://github.com/yahoo/kafka-manager/issues/67