### PR TITLE
add check for topics undergoing reassignment

### DIFF
--- a/app/assets/stylesheets/index.less
+++ b/app/assets/stylesheets/index.less
@@ -39,6 +39,7 @@
 
 .glow-red {
   outline: none;
-  border-color: #ff6c47;
-  box-shadow: 0 0 10px #ff6c47;
+  border-color: #ffd1d1;
+  box-shadow: 0 0 10px #ffd1d1;
+  border-style: solid;
 }

--- a/app/controllers/ReassignPartitions.scala
+++ b/app/controllers/ReassignPartitions.scala
@@ -103,8 +103,7 @@ object ReassignPartitions extends Controller{
   }
 
   def confirmMultipleAssignments(c: String) = Action.async {
-    val topicList = kafkaManager.getTopicList(c)
-    topicList.flatMap { errOrTL =>
+    kafkaManager.getTopicList(c).flatMap { errOrTL =>
       errOrTL.fold(
       { err: ApiError =>
         Future.successful( Ok(views.html.topic.confirmMultipleAssignments( c, -\/(err) )))

--- a/app/kafka/manager/ClusterManagerActor.scala
+++ b/app/kafka/manager/ClusterManagerActor.scala
@@ -260,12 +260,17 @@ class ClusterManagerActor(cmConfig: ClusterManagerActorConfig)
         implicit val ec = longRunningExecutionContext
         val eventualBrokerList = withKafkaStateActor(KSGetBrokers)(identity[BrokerList])
         val eventualDescriptions = withKafkaStateActor(KSGetTopicDescriptions(topics))(identity[TopicDescriptions])
+        val eventualReassignPartitions = withKafkaStateActor(KSGetReassignPartition)(identity[Option[ReassignPartitions]])
         val generated: Future[IndexedSeq[(String, Map[Int, Seq[Int]])]] = for {
           bl <- eventualBrokerList
           tds <- eventualDescriptions
+          rp <- eventualReassignPartitions
           tis = tds.descriptions.map(TopicIdentity.from(bl, _, None,cmConfig.clusterConfig))
         } yield {
           bl.list.map(_.id.toInt)
+          // check if any topic undergoing reassignment got selected for reassignment
+          val topicsUndergoingReassignment = getTopicsUnderReassignment(rp, topics)
+          require(topicsUndergoingReassignment.isEmpty, "Topic(s) already undergoing reassignment(s): [%s]".format(topicsUndergoingReassignment.mkString(", ")))
           // check if any nonexistent broker got selected for reassignment
           val nonExistentBrokers = getNonExistentBrokers(bl, brokers)
           require(nonExistentBrokers.isEmpty, "Nonexistent broker(s) selected: [%s]".format(nonExistentBrokers.mkString(", ")))
@@ -382,5 +387,14 @@ class ClusterManagerActor(cmConfig: ClusterManagerActorConfig)
   def getNonExistentBrokers(availableBrokers: BrokerList, assignments: Map[Int, Seq[Int]]): Seq[Int] = {
     val brokersAssigned = assignments.flatMap({ case  (pt, bl) => bl }).toSet.toSeq
     getNonExistentBrokers(availableBrokers, brokersAssigned)
+  }
+
+  def getTopicsUnderReassignment(reassignPartitions: Option[ReassignPartitions], topicsToBeReassigned: Set[String]): Set[String] = {
+    val topicsUnderReassignment = reassignPartitions.map { asgn =>
+      asgn.endTime.map(_ => Set[String]()).getOrElse{
+        asgn.partitionsToBeReassigned.map { case (t,s) => t.topic}.toSet
+      }
+    }.getOrElse(Set[String]())
+    topicsToBeReassigned.intersect(topicsUnderReassignment)
   }
 }


### PR DESCRIPTION
Addresses issue #75 . This patch makes KM not to generate reassignments when any of the selected topics is already undergoing reassignments. Also changed the border color to lighter red (indication that the topic is under reassignment).