### PR TITLE
Manual partition assignment

### DIFF
--- a/app/assets/stylesheets/index.less
+++ b/app/assets/stylesheets/index.less
@@ -42,3 +42,23 @@
   border-color: #ff6c47;
   box-shadow: 0 0 10px #ff6c47;
 }
+
+.assignment-pane {
+  margin: 0 auto;
+  text-align: center;
+}
+
+.assignment-cell {
+  display: inline-block;
+  vertical-align: top;
+  margin: 1% 1% 1% 1%;
+  border-style: solid;
+  border-width: thin;
+  border-radius: 8px;
+  padding: inherit;
+  border-color: rgb(190, 190, 190);
+}
+
+.assignment-cell table tbody tr td {
+  padding-left: 3%;
+}

--- a/app/assets/stylesheets/index.less
+++ b/app/assets/stylesheets/index.less
@@ -73,10 +73,29 @@
 }
 
 .float-right {
-  float:right;
+  float: right;
 }
 
 .borderless {
   border: hidden;
   width: 25%;
+}
+
+.sub-heading {
+  padding-top: 0;
+  padding-bottom: 0;
+  text-align: center;
+}
+
+.sub-heading input {
+  width: 50%;
+}
+
+.btn-group-vertical button .glyphicon {
+  float: left;
+}
+
+#selectMetrics {
+  width: 100%;
+  margin-bottom: 3%;
 }

--- a/app/assets/stylesheets/index.less
+++ b/app/assets/stylesheets/index.less
@@ -60,5 +60,38 @@
 }
 
 .assignment-cell table tbody tr td {
-  padding-left: 3%;
+  padding-left: 2%;
+  padding-right: 2%;
+}
+
+.assignment-cell table tr td {
+  text-align: left;
+  padding-top: 2%;
+  padding-bottom: 2%;
+}
+
+dl dt {
+  display: none;
+}
+
+dl {
+  margin-bottom: 0;
+}
+
+.wrapless {
+  white-space: nowrap;
+  padding-right: 5%;
+  margin-right: 5%;
+}
+
+.float-right {
+  float:right;
+}
+
+.borderless {
+  border: hidden;
+}
+
+.center-text {
+  text-align: center;
 }

--- a/app/assets/stylesheets/index.less
+++ b/app/assets/stylesheets/index.less
@@ -72,10 +72,6 @@
   text-align: left;
 }
 
-.float-right {
-  float: right;
-}
-
 .borderless {
   border: hidden;
   width: 25%;

--- a/app/assets/stylesheets/index.less
+++ b/app/assets/stylesheets/index.less
@@ -49,12 +49,9 @@
 }
 
 .assignment-cell {
-  display: inline-block;
-  vertical-align: top;
   margin: 1% 1% 1% 1%;
   border-style: solid;
   border-width: thin;
-  border-radius: 8px;
   padding: inherit;
   border-color: rgb(190, 190, 190);
 }
@@ -70,6 +67,11 @@
   padding-bottom: 2%;
 }
 
+.partition-cell {
+  display: inline-block;
+  vertical-align: top;
+}
+
 dl dt {
   display: none;
 }
@@ -78,20 +80,10 @@ dl {
   margin-bottom: 0;
 }
 
-.wrapless {
-  white-space: nowrap;
-  padding-right: 5%;
-  margin-right: 5%;
-}
-
 .float-right {
   float:right;
 }
 
 .borderless {
   border: hidden;
-}
-
-.center-text {
-  text-align: center;
 }

--- a/app/assets/stylesheets/index.less
+++ b/app/assets/stylesheets/index.less
@@ -53,6 +53,7 @@
   border-style: solid;
   border-width: thin;
   padding: inherit;
+  padding-top: 0;
   border-color: rgb(190, 190, 190);
 }
 

--- a/app/assets/stylesheets/index.less
+++ b/app/assets/stylesheets/index.less
@@ -45,7 +45,6 @@
 
 .assignment-pane {
   margin: 0 auto;
-  text-align: center;
 }
 
 .assignment-cell {
@@ -55,30 +54,22 @@
   padding: inherit;
   padding-top: 0;
   border-color: rgb(190, 190, 190);
+  text-align: center;
 }
 
-.assignment-cell table tbody tr td {
-  padding-left: 2%;
-  padding-right: 2%;
-}
-
-.assignment-cell table tr td {
-  text-align: left;
-  padding-top: 2%;
-  padding-bottom: 2%;
+.assignment-cell h4 {
+  text-align: center;
 }
 
 .partition-cell {
   display: inline-block;
   vertical-align: top;
-}
-
-dl dt {
-  display: none;
-}
-
-dl {
-  margin-bottom: 0;
+  border-style: solid;
+  border-width: thin;
+  border-color: rgb(200, 200, 200);
+  padding: 1% 1% 1% 1%;
+  margin: 0 0 0 0;
+  text-align: left;
 }
 
 .float-right {
@@ -87,4 +78,5 @@ dl {
 
 .borderless {
   border: hidden;
+  width: 25%;
 }

--- a/app/kafka/manager/ActorModel.scala
+++ b/app/kafka/manager/ActorModel.scala
@@ -316,7 +316,8 @@ object ActorModel {
                            bytesRejectedPerSec: MeterMetric,
                            failedFetchRequestsPerSec: MeterMetric,
                            failedProduceRequestsPerSec: MeterMetric,
-                           messagesInPerSec: MeterMetric) {
+                           messagesInPerSec: MeterMetric,
+                           oSystemMetrics: OSMetric) {
     def +(o: BrokerMetrics) : BrokerMetrics = {
       BrokerMetrics(
         o.bytesInPerSec + bytesInPerSec,
@@ -324,7 +325,8 @@ object ActorModel {
         o.bytesRejectedPerSec + bytesRejectedPerSec,
         o.failedFetchRequestsPerSec + failedFetchRequestsPerSec,
         o.failedProduceRequestsPerSec + failedProduceRequestsPerSec,
-        o.messagesInPerSec + messagesInPerSec)
+        o.messagesInPerSec + messagesInPerSec,
+        oSystemMetrics)
     }
 
   }
@@ -336,7 +338,8 @@ object ActorModel {
       MeterMetric(0, 0, 0, 0, 0),
       MeterMetric(0, 0, 0, 0, 0),
       MeterMetric(0, 0, 0, 0, 0),
-      MeterMetric(0, 0, 0, 0, 0))
+      MeterMetric(0, 0, 0, 0, 0),
+      OSMetric(0L, 0L, 0D, 0D))
   }
   
   case class BrokerClusterStats(perMessages: BigDecimal, perIncoming: BigDecimal, perOutgoing: BigDecimal)

--- a/app/kafka/manager/ActorModel.scala
+++ b/app/kafka/manager/ActorModel.scala
@@ -34,6 +34,7 @@ object ActorModel {
   case object BVForceUpdate extends CommandRequest
   case object BVGetTopicIdentities extends BVRequest
   case class BVGetView(id: Int) extends BVRequest
+  case object BVGetViews extends BVRequest
   case class BVGetTopicMetrics(topic: String) extends BVRequest
   case object BVGetBrokerMetrics extends BVRequest
   case class BVView(topicPartitions: Map[TopicIdentity, IndexedSeq[Int]], clusterConfig: ClusterConfig,

--- a/app/kafka/manager/ActorModel.scala
+++ b/app/kafka/manager/ActorModel.scala
@@ -65,6 +65,7 @@ object ActorModel {
   case class CMRunPreferredLeaderElection(topics: Set[String]) extends CommandRequest
   case class CMRunReassignPartition(topics: Set[String]) extends CommandRequest
   case class CMGeneratePartitionAssignments(topics: Set[String], brokers: Seq[Int]) extends CommandRequest
+  case class CMManualPartitionAssignments(assignments: List[(String, List[(Int, List[Int])])]) extends CommandRequest
 
 
   case class CMCommandResult(result: Try[Unit]) extends CommandResponse

--- a/app/kafka/manager/ActorModel.scala
+++ b/app/kafka/manager/ActorModel.scala
@@ -339,7 +339,7 @@ object ActorModel {
       MeterMetric(0, 0, 0, 0, 0),
       MeterMetric(0, 0, 0, 0, 0),
       MeterMetric(0, 0, 0, 0, 0),
-      OSMetric(0L, 0L, 0D, 0D))
+      OSMetric(0D, 0D))
   }
   
   case class BrokerClusterStats(perMessages: BigDecimal, perIncoming: BigDecimal, perOutgoing: BigDecimal)

--- a/app/kafka/manager/KafkaJMX.scala
+++ b/app/kafka/manager/KafkaJMX.scala
@@ -126,16 +126,14 @@ object KafkaMetrics {
     try {
       val attributes = mbsc.getAttributes(
         operatingSystemObjectName,
-        Array("FreePhysicalMemorySize", "FreeSwapSpaceSize", "ProcessCpuLoad", "SystemCpuLoad")
+        Array("ProcessCpuLoad", "SystemCpuLoad")
       ).asList().asScala.toSeq
       OSMetric(
-        getLongValue(attributes, "FreePhysicalMemorySize"),
-        getLongValue(attributes, "FreeSwapSpaceSize"),
         getDoubleValue(attributes, "ProcessCpuLoad"),
         getDoubleValue(attributes, "SystemCpuload")
       )
     } catch {
-      case _: InstanceNotFoundException => OSMetric(0L, 0L, 0D, 0D)
+      case _: InstanceNotFoundException => OSMetric(0D, 0D)
     }
   }
   
@@ -176,18 +174,8 @@ object KafkaMetrics {
 
 case class GaugeMetric(value: Double)
 
-case class OSMetric(freePhysicalMemorySize: Double,
-                     freeSwapSpaceSize: Double,
-                     processCpuLoad: Double,
-                     systemCpuLoad: Double) {
-
-  def formatFreePhysicalMemory = {
-    FormatMetric.rateFormat(freePhysicalMemorySize.toDouble, 0)
-  }
-
-  def formatFreeSwapSpace = {
-    FormatMetric.rateFormat(freeSwapSpaceSize.toDouble, 0)
-  }
+case class OSMetric(processCpuLoad: Double,
+                    systemCpuLoad: Double) {
 
   def formatProcessCpuLoad = {
     FormatMetric.rateFormat(processCpuLoad, 0)

--- a/app/kafka/manager/KafkaManager.scala
+++ b/app/kafka/manager/KafkaManager.scala
@@ -14,6 +14,7 @@ import com.typesafe.config.{ConfigFactory, Config}
 import kafka.manager.ActorModel._
 import org.slf4j.{LoggerFactory, Logger}
 
+import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
@@ -410,6 +411,17 @@ class KafkaManager(akkaConfig: Config)
         }
       })
     }
+  }
+
+  def getBrokersView(clusterName: String): Future[\/[ApiError, Seq[BVView]]] = {
+    implicit val ec = apiExecutionContext
+
+    tryWithKafkaManagerActor(
+      KMClusterQueryRequest(
+        clusterName,
+        BVGetViews
+      )
+    )(identity[Seq[BVView]])
   }
 
   def getBrokerView(clusterName: String, brokerId: Int): Future[ApiError \/ BVView] = {

--- a/app/kafka/manager/utils/Helpers.scala
+++ b/app/kafka/manager/utils/Helpers.scala
@@ -1,0 +1,12 @@
+package kafka.manager.utils
+
+import play.twirl.api._
+
+object repeatWithIndex {
+
+  import play.api.data.Field
+
+  def apply(field: play.api.data.Field, min: Int = 1)(f: (Field,Int) => Html) = {
+    (0 until math.max(if (field.indexes.isEmpty) 0 else field.indexes.max + 1, min)).map(i => f(field("[" + i + "]"),i))
+  }
+}

--- a/app/views/common/expandedBrokerMetrics.scala.html
+++ b/app/views/common/expandedBrokerMetrics.scala.html
@@ -3,11 +3,15 @@
     <tr>
         <th>Rate</th>
         <th>Mean</th>
+        <th>15&nbsp;min</th>
     </tr>
     <tr class="metric-row" name="messages in sec">
         <td>Messages in /sec</td>
         <td>
             <span class="badge">@brokerMetrics.map(_.messagesInPerSec.formatMeanRate)</span>
+        </td>
+        <td>
+            <span class="badge">@brokerMetrics.map(_.messagesInPerSec.formatFifteenMinuteRate)</span>
         </td>
     <tr>
     <tr class="metric-row" name="bytes in sec">
@@ -15,11 +19,17 @@
         <td>
             <span class="badge">@brokerMetrics.map(_.bytesInPerSec.formatMeanRate)</span>
         </td>
+        <td>
+            <span class="badge">@brokerMetrics.map(_.bytesInPerSec.formatFifteenMinuteRate)</span>
+        </td>
     <tr>
     <tr class="metric-row" name="bytes out sec">
         <td>Bytes out /sec</td>
         <td>
             <span class="badge">@brokerMetrics.map(_.bytesOutPerSec.formatMeanRate)</span>
+        </td>
+        <td>
+            <span class="badge">@brokerMetrics.map(_.bytesOutPerSec.formatFifteenMinuteRate)</span>
         </td>
     <tr>
     <tr class="metric-row" name="bytes rejected sec">
@@ -27,11 +37,17 @@
         <td>
             <span class="badge">@brokerMetrics.map(_.bytesRejectedPerSec.formatMeanRate)</span>
         </td>
+        <td>
+            <span class="badge">@brokerMetrics.map(_.bytesRejectedPerSec.formatFifteenMinuteRate)</span>
+        </td>
     <tr>
     <tr class="metric-row" name="failed fetch request sec">
         <td>Failed fetch request /sec</td>
         <td>
             <span class="badge">@brokerMetrics.map(_.failedFetchRequestsPerSec.formatMeanRate)</span>
+        </td>
+        <td>
+            <span class="badge">@brokerMetrics.map(_.failedFetchRequestsPerSec.formatFifteenMinuteRate)</span>
         </td>
     <tr>
     <tr class="metric-row" name="failed produce request">
@@ -39,17 +55,8 @@
         <td>
             <span class="badge">@brokerMetrics.map(_.failedProduceRequestsPerSec.formatMeanRate)</span>
         </td>
-    <tr>
-    <tr class="metric-row" name="free physical memory size">
-        <td>Free Physical Memory Size</td>
         <td>
-            <span class="badge">@brokerMetrics.map(_.oSystemMetrics.formatFreePhysicalMemory)</span>
-        </td>
-    <tr>
-    <tr class="metric-row" name="free swap space size">
-        <td>Free Swap Space Size</td>
-        <td>
-            <span class="badge">@brokerMetrics.map(_.oSystemMetrics.formatFreeSwapSpace)</span>
+            <span class="badge">@brokerMetrics.map(_.failedProduceRequestsPerSec.formatFifteenMinuteRate)</span>
         </td>
     <tr>
     <tr class="metric-row" name="process cpu load">
@@ -57,11 +64,13 @@
         <td>
             <span class="badge">@brokerMetrics.map(_.oSystemMetrics.formatProcessCpuLoad)</span>
         </td>
+        <td></td>
     <tr>
     <tr class="metric-row" name="system cpu load">
         <td>System CPU Load</td>
         <td>
             <span class="badge">@brokerMetrics.map(_.oSystemMetrics.formatSystemCpuLoad)</span>
         </td>
+        <td></td>
     <tr>
 </table>

--- a/app/views/common/expandedBrokerMetrics.scala.html
+++ b/app/views/common/expandedBrokerMetrics.scala.html
@@ -1,71 +1,67 @@
 @(brokerMetrics: Option[kafka.manager.ActorModel.BrokerMetrics])
 <table class="table">
-    <thead>
     <tr>
         <th>Rate</th>
         <th>Mean</th>
     </tr>
-    </thead>
-    <tbody>
-    <tr>
+    <tr class="metric-row" name="messages in sec">
         <td>Messages in /sec</td>
         <td>
             <span class="badge">@brokerMetrics.map(_.messagesInPerSec.formatMeanRate)</span>
         </td>
     <tr>
-    <tr>
+    <tr class="metric-row" name="bytes in sec">
         <td>Bytes in /sec</td>
         <td>
             <span class="badge">@brokerMetrics.map(_.bytesInPerSec.formatMeanRate)</span>
         </td>
     <tr>
-    <tr>
+    <tr class="metric-row" name="bytes out sec">
         <td>Bytes out /sec</td>
         <td>
             <span class="badge">@brokerMetrics.map(_.bytesOutPerSec.formatMeanRate)</span>
         </td>
     <tr>
-    <tr>
+    <tr class="metric-row" name="bytes rejected sec">
         <td>Bytes rejected /sec</td>
         <td>
             <span class="badge">@brokerMetrics.map(_.bytesRejectedPerSec.formatMeanRate)</span>
         </td>
     <tr>
-    <tr>
+    <tr class="metric-row" name="failed fetch request sec">
         <td>Failed fetch request /sec</td>
         <td>
             <span class="badge">@brokerMetrics.map(_.failedFetchRequestsPerSec.formatMeanRate)</span>
         </td>
     <tr>
-    <tr>
+    <tr class="metric-row" name="failed produce request">
         <td>Failed produce request /sec</td>
         <td>
             <span class="badge">@brokerMetrics.map(_.failedProduceRequestsPerSec.formatMeanRate)</span>
         </td>
     <tr>
-    <tr>
+    <tr class="metric-row" name="free physical memory size">
         <td>Free Physical Memory Size</td>
         <td>
             <span class="badge">@brokerMetrics.map(_.oSystemMetrics.formatFreePhysicalMemory)</span>
         </td>
     <tr>
-    <tr>
+    <tr class="metric-row" name="free swap space size">
         <td>Free Swap Space Size</td>
         <td>
             <span class="badge">@brokerMetrics.map(_.oSystemMetrics.formatFreeSwapSpace)</span>
         </td>
     <tr>
-    <tr>
+    <tr class="metric-row" name="process cpu load">
         <td>Process CPU Load</td>
         <td>
             <span class="badge">@brokerMetrics.map(_.oSystemMetrics.formatProcessCpuLoad)</span>
         </td>
     <tr>
-    <tr>
+    <tr class="metric-row" name="system cpu load">
         <td>System CPU Load</td>
         <td>
             <span class="badge">@brokerMetrics.map(_.oSystemMetrics.formatSystemCpuLoad)</span>
         </td>
     <tr>
-    </tbody>
 </table>

--- a/app/views/common/expandedBrokerMetrics.scala.html
+++ b/app/views/common/expandedBrokerMetrics.scala.html
@@ -1,0 +1,71 @@
+@(brokerMetrics: Option[kafka.manager.ActorModel.BrokerMetrics])
+<table class="table">
+    <thead>
+    <tr>
+        <th>Rate</th>
+        <th>Mean</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>Messages in /sec</td>
+        <td>
+            <span class="badge">@brokerMetrics.map(_.messagesInPerSec.formatMeanRate)</span>
+        </td>
+    <tr>
+    <tr>
+        <td>Bytes in /sec</td>
+        <td>
+            <span class="badge">@brokerMetrics.map(_.bytesInPerSec.formatMeanRate)</span>
+        </td>
+    <tr>
+    <tr>
+        <td>Bytes out /sec</td>
+        <td>
+            <span class="badge">@brokerMetrics.map(_.bytesOutPerSec.formatMeanRate)</span>
+        </td>
+    <tr>
+    <tr>
+        <td>Bytes rejected /sec</td>
+        <td>
+            <span class="badge">@brokerMetrics.map(_.bytesRejectedPerSec.formatMeanRate)</span>
+        </td>
+    <tr>
+    <tr>
+        <td>Failed fetch request /sec</td>
+        <td>
+            <span class="badge">@brokerMetrics.map(_.failedFetchRequestsPerSec.formatMeanRate)</span>
+        </td>
+    <tr>
+    <tr>
+        <td>Failed produce request /sec</td>
+        <td>
+            <span class="badge">@brokerMetrics.map(_.failedProduceRequestsPerSec.formatMeanRate)</span>
+        </td>
+    <tr>
+    <tr>
+        <td>Free Physical Memory Size</td>
+        <td>
+            <span class="badge">@brokerMetrics.map(_.oSystemMetrics.formatFreePhysicalMemory)</span>
+        </td>
+    <tr>
+    <tr>
+        <td>Free Swap Space Size</td>
+        <td>
+            <span class="badge">@brokerMetrics.map(_.oSystemMetrics.formatFreeSwapSpace)</span>
+        </td>
+    <tr>
+    <tr>
+        <td>Process CPU Load</td>
+        <td>
+            <span class="badge">@brokerMetrics.map(_.oSystemMetrics.formatProcessCpuLoad)</span>
+        </td>
+    <tr>
+    <tr>
+        <td>System CPU Load</td>
+        <td>
+            <span class="badge">@brokerMetrics.map(_.oSystemMetrics.formatSystemCpuLoad)</span>
+        </td>
+    <tr>
+    </tbody>
+</table>

--- a/app/views/common/shortBrokerMetrics.scala.html
+++ b/app/views/common/shortBrokerMetrics.scala.html
@@ -1,0 +1,79 @@
+@import kafka.manager.ActorModel.{TopicIdentity, BVView}
+
+@(brokersViews: Seq[BVView])
+
+<table class="table">
+    <tr>
+      <th>Broker </th>
+      <th>Messages in /sec</th>
+      <th>Bytes in /sec</th>
+      <th>Bytes out /sec</th>
+    </tr>
+  @brokersViews.zipWithIndex.map { case (brokerView, idx) =>
+      @if(brokerView.clusterConfig.jmxEnabled) {
+      <tr>
+        <td>@idx</td>
+        <td>
+          <span class="badge">@brokerView.metrics.map(_.messagesInPerSec.formatMeanRate)</span>
+        </td>
+        <td>
+          <span class="badge">@brokerView.metrics.map(_.bytesInPerSec.formatMeanRate)</span>
+        </td>
+        <td>
+          <span class="badge">@brokerView.metrics.map(_.bytesOutPerSec.formatMeanRate)</span>
+        </td>
+      </tr>
+  } else {
+      <tr>
+        <td>@idx</td>
+        <td>
+          <span class="badge">NA</span>
+        </td>
+        <td>
+          <span class="badge">NA</span>
+        </td>
+        <td>
+          <span class="badge">NA</span>
+        </td>
+      </tr>
+  }
+  }
+</table>
+
+<table class="table">
+  <tr>
+    <th>Broker </th>
+    <th>Bytes rejected /sec</th>
+    <th>Failed fetch request /sec</th>
+    <th>Failed produce request /sec</th>
+  </tr>
+  @brokersViews.zipWithIndex.map { case (brokerView, idx) =>
+  @if(brokerView.clusterConfig.jmxEnabled) {
+  <tr>
+    <td>@idx</td>
+    <td>
+      <span class="badge">@brokerView.metrics.map(_.bytesRejectedPerSec.formatMeanRate)</span>
+    </td>
+    <td>
+      <span class="badge">@brokerView.metrics.map(_.failedFetchRequestsPerSec.formatMeanRate)</span>
+    </td>
+    <td>
+      <span class="badge">@brokerView.metrics.map(_.failedProduceRequestsPerSec.formatMeanRate)</span>
+    </td>
+  </tr>
+  } else {
+  <tr>
+    <td>@idx</td>
+    <td>
+      <span class="badge">NA</span>
+    </td>
+    <td>
+      <span class="badge">NA</span>
+    </td>
+    <td>
+      <span class="badge">NA</span>
+    </td>
+  </tr>
+  }
+  }
+</table>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -38,8 +38,17 @@
         window.history.back()
     }
 
-    function checkBoxSelect(idPrefix, booleanValue) {
+    function checkBoxSelect(idPrefix, booleanValue, display) {
         $("[id^="+idPrefix+"]").prop("checked",booleanValue);
+    }
+
+    function selectBySubname(selectId, selectClass, display) {
+        var subname = $(selectId).val().toLowerCase();
+        $('.' + selectClass).not("[name*='" + subname + "']").css("display", "none");
+        $("[class='"+selectClass+"'][name*='"+subname+"']").css("display", display);
+        if (subname == "") {
+            $('.' + selectClass).css("display", display);
+        }
     }
 </script>
 @scripts

--- a/app/views/topic/manualMultipleAssignments.scala.html
+++ b/app/views/topic/manualMultipleAssignments.scala.html
@@ -33,22 +33,20 @@
 @topHeading = {
 <div class="panel-heading">
     <div class="row">
-        <h3 class="col-md-8">
-            <button type="button" class="btn btn-link" onclick="goBack()">
-                <span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>
-            </button>
-            Manual Partition Assignments
+        <h3>
+            <div class="col-md-8">
+                <button type="button" class="btn btn-link" onclick="goBack()">
+                    <span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>
+                </button>
+                Manual Partition Assignments
+            </div>
+            <div class="btn-group-vertical col-md-4" role="group" aria-label="...">
+                <button class="btn btn-primary " type="submit">
+                    <span class="glyphicon glyphicon-floppy-disk"></span>
+                    Save Partition Assignment
+                </button>
+            </div>
         </h3>
-        <div class="btn-group-vertical col-md-4" role="group" aria-label="...">
-            <button type="button" class="btn btn-sm btn-default">
-                <span class="glyphicon glyphicon-flash"></span>
-                Suggest Partition Assignment
-            </button>
-            <button class="btn btn-sm btn-primary" type="submit">
-                <span class="glyphicon glyphicon-floppy-disk"></span>
-                Save Partition Assignment
-            </button>
-        </div>
     </div>
 </div>
 }

--- a/app/views/topic/manualMultipleAssignments.scala.html
+++ b/app/views/topic/manualMultipleAssignments.scala.html
@@ -2,12 +2,16 @@
 * Copyright 2015 Yahoo Inc. Licensed under the Apache License, Version 2.0
 * See accompanying LICENSE file.
 *@
+
 @import scalaz.{\/}
 @import b3.vertical.fieldConstructor
-@import kafka.manager.ActorModel.{TopicIdentity}
+@import kafka.manager.ActorModel.{TopicIdentity, BVView}
+@import kafka.manager.{BrokerListExtended}
+
 @(cluster: String,
   topicsList: IndexedSeq[(String, Option[TopicIdentity])],
-  brokersCount: Int
+  brokers: BrokerListExtended,
+  brokersViews: Seq[BVView]
 )
 
 @theMenu = {
@@ -16,7 +20,7 @@
 
 @replicaSelection(topic: String, partition: Int, replica: Int, curBroker: Int) = {
 <select name="@topic-@partition-@replica" id="@topic-@partition-@replica">
-    @for(broker <- 0 until brokersCount) {
+    @for(broker <- 0 until brokers.list.size) {
         <option value="@broker" @if(broker == curBroker){selected}>Broker @broker</option>
     }
 </select>
@@ -58,14 +62,19 @@
 }
 
 @brokersInfoPane = {
+    @views.html.common.shortBrokerMetrics(brokersViews)
 }
 
 @main(
   "Manual Multiple Assignment",
   menu = theMenu,
   breadcrumbs=views.html.navigation.breadCrumbs(models.navigation.BreadCrumbs.withViewAndCluster("Topics",cluster))) {
-<div class="col-md-8 un-pad-me">
-    @partitionsAssignmentsPane
-    @brokersInfoPane
+<div class="row">
+    <div class="col-md-8">
+        @partitionsAssignmentsPane
+    </div>
+    <div class="col-md-4">
+        @brokersInfoPane
+    </div>
 </div>
 }

--- a/app/views/topic/manualMultipleAssignments.scala.html
+++ b/app/views/topic/manualMultipleAssignments.scala.html
@@ -77,7 +77,10 @@
 }
 
 @brokersInfoPane = {
-    @views.html.common.shortBrokerMetrics(brokersViews)
+    @for(idx <- 0 until brokersViews.size) {
+        <h4 class="alert alert-info">Broker @idx</h4>
+        @views.html.common.brokerMetrics(brokersViews(idx).metrics)
+    }
 }
 
 @main(

--- a/app/views/topic/manualMultipleAssignments.scala.html
+++ b/app/views/topic/manualMultipleAssignments.scala.html
@@ -30,56 +30,86 @@
     </select>
 }
 
-@partitionsAssignmentsPane = {
-<div class="panel panel-default">
-    <div class="panel-heading">
-        <h3>
+@topHeading = {
+<div class="panel-heading">
+    <div class="row">
+        <h3 class="col-md-8">
             <button type="button" class="btn btn-link" onclick="goBack()">
                 <span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>
             </button>
             Manual Partition Assignments
-            <button class="btn btn-primary float-right" type="submit">Save Partition Assignment</button>
         </h3>
-    </div>
-    <div class="panel-body assignment-pane">
-        @repeat(assignForm("topics")) { partitionAssignment =>
-        <div class="assignment-cell">
-            <h4>
-            <input type="text" class="borderless" style="display:none"
-                   name='@partitionAssignment("topic").name'
-                   value='@partitionAssignment("topic").value.get' readonly/>
-            @partitionAssignment("topic").value.get
-            </h4>
-                @repeat(partitionAssignment("assignments")) { assignment =>
-                    @if(assignment("partition").value.isDefined) {
-                        <div class="partition-cell">
-                        <table>
-                        @repeatWithIndex(assignment("brokers")) { (broker, index) =>
-                                    @if(index == 0) {
-                                        <tr>
-                                        <th>Partition
-                                            <input type="number" class="borderless"
-                                               name='@assignment("partition").name'
-                                               value='@assignment("partition").value.get'
-                                               readonly>
-                                        </th>
-                                        </tr>
-                                    }
-                                    <tr><td>
-                                    Replica @index: @replicaSelection(broker)
-                                    </td></tr>
-                        }
-                        </table>
-                        </div>
-                    }
-                }
+        <div class="btn-group-vertical col-md-4" role="group" aria-label="...">
+            <button type="button" class="btn btn-sm btn-default">
+                <span class="glyphicon glyphicon-flash"></span>
+                Suggest Partition Assignment
+            </button>
+            <button class="btn btn-sm btn-primary" type="submit">
+                <span class="glyphicon glyphicon-floppy-disk"></span>
+                Save Partition Assignment
+            </button>
         </div>
-        }
     </div>
 </div>
 }
 
+@middleHeading = {
+<div class="panel-body btn-group-xs sub-heading">
+    <input type="text" placeholder="Type to filter topics"
+           id="cell-selector" onkeyup="selectBySubname('#cell-selector', 'assignment-cell', 'block')"/>
+</div>
+}
+
+@mainBody = {
+<div class="panel-body assignment-pane">
+    @repeat(assignForm("topics")) { partitionAssignment =>
+    <div class="assignment-cell" name='@partitionAssignment("topic").value.get'>
+        <h4>
+            <input type="text" class="borderless" style="display:none"
+                   name='@partitionAssignment("topic").name'
+                   value='@partitionAssignment("topic").value.get' readonly/>
+            @partitionAssignment("topic").value.get
+        </h4>
+        @repeat(partitionAssignment("assignments")) { assignment =>
+        @if(assignment("partition").value.isDefined) {
+        <div class="partition-cell">
+            <table>
+                @repeatWithIndex(assignment("brokers")) { (broker, index) =>
+                @if(index == 0) {
+                <tr>
+                    <th>Partition
+                        <input type="number" class="borderless"
+                               name='@assignment("partition").name'
+                               value='@assignment("partition").value.get'
+                               readonly>
+                    </th>
+                </tr>
+                }
+                <tr><td>
+                    Replica @index: @replicaSelection(broker)
+                </td></tr>
+                }
+            </table>
+        </div>
+        }
+        }
+    </div>
+    }
+</div>
+
+}
+
+@partitionsAssignmentsPane = {
+<div class="panel panel-default">
+    @topHeading
+    @middleHeading
+    @mainBody
+</div>
+}
+
 @brokersInfoPane = {
+    <input type="text" placeholder="Type to filter metrics"
+           id="selectMetrics" onkeyup="selectBySubname('#selectMetrics', 'metric-row', '')"/>
     @for(idx <- 0 until brokersViews.size) {
         <div class="panel panel-default">
             <div class="panel-heading">
@@ -96,7 +126,7 @@
   breadcrumbs=views.html.navigation.breadCrumbs(models.navigation.BreadCrumbs.withViewAndCluster("Topics",cluster))) {
 <div class="row">
     <div class="col-md-8">
-        @if(brokers != null) {
+        @if(true) {
             @helper.form(action = routes.ReassignPartitions.handleManualAssignment(cluster)) {
                 @partitionsAssignmentsPane
             }

--- a/app/views/topic/manualMultipleAssignments.scala.html
+++ b/app/views/topic/manualMultipleAssignments.scala.html
@@ -81,8 +81,12 @@
 
 @brokersInfoPane = {
     @for(idx <- 0 until brokersViews.size) {
-        <h4 class="alert alert-info">Broker @idx</h4>
-        @views.html.common.brokerMetrics(brokersViews(idx).metrics)
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h4>Broker @idx</h4>
+            </div>
+            @views.html.common.expandedBrokerMetrics(brokersViews(idx).metrics)
+        </div>
     }
 }
 

--- a/app/views/topic/manualMultipleAssignments.scala.html
+++ b/app/views/topic/manualMultipleAssignments.scala.html
@@ -50,11 +50,11 @@
                    value='@partitionAssignment("topic").value.get' readonly/>
             @partitionAssignment("topic").value.get
             </h4>
-            <table>
                 @repeat(partitionAssignment("assignments")) { assignment =>
                     @if(assignment("partition").value.isDefined) {
+                        <div class="partition-cell">
+                        <table>
                         @repeatWithIndex(assignment("brokers")) { (broker, index) =>
-                            <div class="partition-cell">
                                     @if(index == 0) {
                                         <tr>
                                         <th>Partition
@@ -68,11 +68,11 @@
                                     <tr><td>
                                     Replica @index: @replicaSelection(broker)
                                     </td></tr>
-                            </div>
                         }
+                        </table>
+                        </div>
                     }
                 }
-                </table>
         </div>
         }
     </div>

--- a/app/views/topic/manualMultipleAssignments.scala.html
+++ b/app/views/topic/manualMultipleAssignments.scala.html
@@ -7,55 +7,70 @@
 @import b3.vertical.fieldConstructor
 @import kafka.manager.ActorModel.{TopicIdentity, BVView}
 @import kafka.manager.{BrokerListExtended}
+@import kafka.manager.utils._
+@import helper._
+@import models.form._
 
 @(cluster: String,
-  topicsList: IndexedSeq[(String, Option[TopicIdentity])],
+  assignForm: Form[List[(String, List[(Int,List[Int])])]],
   brokers: BrokerListExtended,
-  brokersViews: Seq[BVView]
+  brokersViews: Seq[BVView],
+  formErrors: Seq[FormError]
 )
 
 @theMenu = {
 @views.html.navigation.clusterMenu(cluster,"Topic","Manual Partition Assignments",models.navigation.Menus.clusterMenus(cluster))
 }
 
-@replicaSelection(topic: String, partition: Int, replica: Int, curBroker: Int) = {
-<select name="@topic-@partition-@replica" id="@topic-@partition-@replica">
-    @for(broker <- 0 until brokers.list.size) {
-        <option value="@broker" @if(broker == curBroker){selected}>Broker @broker</option>
-    }
-</select>
+@replicaSelection(brokerField: Field) = {
+    <select name="@brokerField.name">
+        @for(idx <- 0 until brokers.list.size) {
+            <option value="@idx" @if(idx == brokerField.value.get.toInt){selected}>Broker @idx</option>
+        }
+    </select>
 }
 
 @partitionsAssignmentsPane = {
 <div class="panel panel-default">
-    <div class="panel-heading"><h3><button type="button" class="btn btn-link" onclick="goBack()"><span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span></button>Manual Partition Assignments</h3></div>
+    <div class="panel-heading">
+        <h3>
+            <button type="button" class="btn btn-link" onclick="goBack()">
+                <span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span>
+            </button>
+            Manual Partition Assignments
+            <button class="btn btn-primary float-right" type="submit">Save Partition Assignment</button>
+        </h3>
+    </div>
     <div class="panel-body assignment-pane">
-        @topicsList.map {
-        case (topic, Some(topicIdentity)) => {
+        @repeat(assignForm("topics")) { partitionAssignment =>
         <div class="assignment-cell">
-            <h3>@topic</h3>
+            <h3>
+            <input type="text" class="borderless center-text"
+                   name='@partitionAssignment("topic").name'
+                   value='@partitionAssignment("topic").value.get' readonly/>
+            </h3>
             <table>
-                @topicIdentity.partitionsIdentity.map { case (partition, topicPartitionIdentity) =>
-                <tr>
-                    <th>Partition @partition</th>
-                    <td>
-                        Replica 0: @replicaSelection(
-                        topic, partition, 0, topicPartitionIdentity.replicas.head
-                        )
-                    </td>
-                </tr>
-                @for(r <- 1 until topicPartitionIdentity.replicas.size) {
-                <tr><td></td><td>
-                    Replica @r: @replicaSelection(
-                    topic, partition, r, topicPartitionIdentity.replicas(r)
-                    )
-                </td><td></td></tr>
-                }
+                @repeat(partitionAssignment("assignments")) { assignment =>
+                    @if(assignment("partition").value.isDefined) {
+                        @repeatWithIndex(assignment("brokers")) { (broker, index) =>
+                                @if(index == 0) {
+                                    <tr>
+                                    <th>Partition
+                                        <input type="number" class="borderless"
+                                           name='@assignment("partition").name'
+                                           value='@assignment("partition").value.get'
+                                           readonly>
+                                    </th>
+                                    </tr>
+                                }
+                            <tr>
+                                <td>Replica @index: @replicaSelection(broker)</td>
+                            </tr>
+                        }
+                    }
                 }
             </table>
         </div>
-        }
-        case (topic, None) => {}
         }
     </div>
 </div>
@@ -71,10 +86,20 @@
   breadcrumbs=views.html.navigation.breadCrumbs(models.navigation.BreadCrumbs.withViewAndCluster("Topics",cluster))) {
 <div class="row">
     <div class="col-md-8">
-        @partitionsAssignmentsPane
+        @if(brokers != null) {
+            @helper.form(action = routes.ReassignPartitions.handleManualAssignment(cluster)) {
+                @partitionsAssignmentsPane
+            }
+        } else {
+            @assignForm.toString
+            <br/><br/><br/><br/><br/>
+            @formErrors.toString
+        }
     </div>
     <div class="col-md-4">
-        @brokersInfoPane
+        @if(brokers != null) {
+            @brokersInfoPane
+        }
     </div>
 </div>
 }

--- a/app/views/topic/manualMultipleAssignments.scala.html
+++ b/app/views/topic/manualMultipleAssignments.scala.html
@@ -44,28 +44,31 @@
     <div class="panel-body assignment-pane">
         @repeat(assignForm("topics")) { partitionAssignment =>
         <div class="assignment-cell">
-            <h3>
-            <input type="text" class="borderless center-text"
+            <h4>
+            <input type="text" class="borderless" style="display:none"
                    name='@partitionAssignment("topic").name'
                    value='@partitionAssignment("topic").value.get' readonly/>
-            </h3>
+            @partitionAssignment("topic").value.get
+            </h4>
             <table>
                 @repeat(partitionAssignment("assignments")) { assignment =>
                     @if(assignment("partition").value.isDefined) {
                         @repeatWithIndex(assignment("brokers")) { (broker, index) =>
-                                @if(index == 0) {
-                                    <tr>
-                                    <th>Partition
-                                        <input type="number" class="borderless"
-                                           name='@assignment("partition").name'
-                                           value='@assignment("partition").value.get'
-                                           readonly>
-                                    </th>
-                                    </tr>
-                                }
-                            <tr>
-                                <td>Replica @index: @replicaSelection(broker)</td>
-                            </tr>
+                            <div class="partition-cell">
+                                    @if(index == 0) {
+                                        <tr>
+                                        <th>Partition
+                                            <input type="number" class="borderless"
+                                               name='@assignment("partition").name'
+                                               value='@assignment("partition").value.get'
+                                               readonly>
+                                        </th>
+                                        </tr>
+                                    }
+                                <tr>
+                                    <td>Replica @index: @replicaSelection(broker)</td>
+                                </tr>
+                            </div>
                         }
                     }
                 }

--- a/app/views/topic/manualMultipleAssignments.scala.html
+++ b/app/views/topic/manualMultipleAssignments.scala.html
@@ -65,14 +65,14 @@
                                         </th>
                                         </tr>
                                     }
-                                <tr>
-                                    <td>Replica @index: @replicaSelection(broker)</td>
-                                </tr>
+                                    <tr><td>
+                                    Replica @index: @replicaSelection(broker)
+                                    </td></tr>
                             </div>
                         }
                     }
                 }
-            </table>
+                </table>
         </div>
         }
     </div>

--- a/app/views/topic/manualMultipleAssignments.scala.html
+++ b/app/views/topic/manualMultipleAssignments.scala.html
@@ -1,0 +1,71 @@
+@*
+* Copyright 2015 Yahoo Inc. Licensed under the Apache License, Version 2.0
+* See accompanying LICENSE file.
+*@
+@import scalaz.{\/}
+@import b3.vertical.fieldConstructor
+@import kafka.manager.ActorModel.{TopicIdentity}
+@(cluster: String,
+  topicsList: IndexedSeq[(String, Option[TopicIdentity])],
+  brokersCount: Int
+)
+
+@theMenu = {
+@views.html.navigation.clusterMenu(cluster,"Topic","Manual Partition Assignments",models.navigation.Menus.clusterMenus(cluster))
+}
+
+@replicaSelection(topic: String, partition: Int, replica: Int, curBroker: Int) = {
+<select name="@topic-@partition-@replica" id="@topic-@partition-@replica">
+    @for(broker <- 0 until brokersCount) {
+        <option value="@broker" @if(broker == curBroker){selected}>Broker @broker</option>
+    }
+</select>
+}
+
+@partitionsAssignmentsPane = {
+<div class="panel panel-default">
+    <div class="panel-heading"><h3><button type="button" class="btn btn-link" onclick="goBack()"><span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span></button>Manual Partition Assignments</h3></div>
+    <div class="panel-body assignment-pane">
+        @topicsList.map {
+        case (topic, Some(topicIdentity)) => {
+        <div class="assignment-cell">
+            <h3>@topic</h3>
+            <table>
+                @topicIdentity.partitionsIdentity.map { case (partition, topicPartitionIdentity) =>
+                <tr>
+                    <th>Partition @partition</th>
+                    <td>
+                        Replica 0: @replicaSelection(
+                        topic, partition, 0, topicPartitionIdentity.replicas.head
+                        )
+                    </td>
+                </tr>
+                @for(r <- 1 until topicPartitionIdentity.replicas.size) {
+                <tr><td></td><td>
+                    Replica @r: @replicaSelection(
+                    topic, partition, r, topicPartitionIdentity.replicas(r)
+                    )
+                </td><td></td></tr>
+                }
+                }
+            </table>
+        </div>
+        }
+        case (topic, None) => {}
+        }
+    </div>
+</div>
+}
+
+@brokersInfoPane = {
+}
+
+@main(
+  "Manual Multiple Assignment",
+  menu = theMenu,
+  breadcrumbs=views.html.navigation.breadCrumbs(models.navigation.BreadCrumbs.withViewAndCluster("Topics",cluster))) {
+<div class="col-md-8 un-pad-me">
+    @partitionsAssignmentsPane
+    @brokersInfoPane
+</div>
+}

--- a/app/views/topic/topicList.scala.html
+++ b/app/views/topic/topicList.scala.html
@@ -31,6 +31,9 @@
                         <a href="@routes.ReassignPartitions.confirmMultipleAssignments(cluster)" class="submit-button btn btn-primary" role="button">Generate Partition Assignments</a>
                     </td>
                     <td>
+                        <a href="@routes.ReassignPartitions.manualMultipleAssignments(cluster)" class="submit-button btn btn-primary" role="button">Manually Set Partition Assignments</a>
+                    </td>
+                    <td>
                         <a href="@routes.ReassignPartitions.runMultipleAssignments(cluster)" class="submit-button btn btn-primary" role="button">Run Partition Assignments</a>
                     </td>
                 </tr>

--- a/conf/routes
+++ b/conf/routes
@@ -21,6 +21,7 @@ POST        /clusters/:c/assignment/generate              controllers.ReassignPa
 GET         /clusters/:c/assignments/confirm              controllers.ReassignPartitions.confirmMultipleAssignments(c:String)
 POST        /clusters/:c/assignments/generate             controllers.ReassignPartitions.handleGenerateMultipleAssignments(c:String)
 GET         /clusters/:c/assignments/manual               controllers.ReassignPartitions.manualMultipleAssignments(c:String)
+POST        /clusters/:c/assignments/manual               controllers.ReassignPartitions.handleManualAssignment(c:String)
 GET         /clusters/:c/assignments/run                  controllers.ReassignPartitions.runMultipleAssignments(c:String)
 POST        /clusters/:c/assignments/run                  controllers.ReassignPartitions.handleRunMultipleAssignments(c:String)
 GET         /addCluster                                   controllers.Cluster.addCluster

--- a/conf/routes
+++ b/conf/routes
@@ -20,6 +20,7 @@ GET         /clusters/:c/assignment/confirm               controllers.ReassignPa
 POST        /clusters/:c/assignment/generate              controllers.ReassignPartitions.handleGenerateAssignment(c:String,t:String)
 GET         /clusters/:c/assignments/confirm              controllers.ReassignPartitions.confirmMultipleAssignments(c:String)
 POST        /clusters/:c/assignments/generate             controllers.ReassignPartitions.handleGenerateMultipleAssignments(c:String)
+GET         /clusters/:c/assignments/manual               controllers.ReassignPartitions.manualMultipleAssignments(c:String)
 GET         /clusters/:c/assignments/run                  controllers.ReassignPartitions.runMultipleAssignments(c:String)
 POST        /clusters/:c/assignments/run                  controllers.ReassignPartitions.handleRunMultipleAssignments(c:String)
 GET         /addCluster                                   controllers.Cluster.addCluster

--- a/test/kafka/manager/TestKafkaManagerActor.scala
+++ b/test/kafka/manager/TestKafkaManagerActor.scala
@@ -142,4 +142,10 @@ class TestKafkaManagerActor extends CuratorAwareTest {
       result.list.nonEmpty
     }
   }
+
+  test("get all broker views") {
+    withKafkaManagerActor(KMClusterQueryRequest("dev", BVGetViews)) {
+      result: Seq[BVView] => result.nonEmpty
+    }
+  }
 }


### PR DESCRIPTION
Automatic random generation of partition assignments limits the user control over them. At times it is necessary, or at least desirable to tweak the assignment and manually make decisions on which replica of which partition goes to. An example of such a situation is when only a small subset of topics takes most of data flow on the cluster, and you may wanna make sure they are separated, in different brokers.

A new view was created for these decisions, where the user can see both the current assignment and some broker metrics to aid on choices. Two metrics were also added to this view: Process CPU Load and System CPU Load.
![screen shot 2015-07-06 at 11 06 44 pm](https://cloud.githubusercontent.com/assets/6502871/8537356/1a7ac9ee-2434-11e5-827f-3fa500c14364.png)

This view can be accessed through the route /clusters/:cluster/assignments/manual or by clicking the button "Manually Set Partition Assignmentns" in /clusters/:cluster/topics.

I hope more people find it useful!

EDIT 1: I also added two filters in this view: to filter topics and to filter metrics, in order to decrease the visual clutter on the page.

EDIT 2: Feedbacks are welcome =p