### PR TITLE
Fix broker skew percentage and under-replicated warning level

### DIFF
--- a/app/views/topic/topicListContent.scala.html
+++ b/app/views/topic/topicListContent.scala.html
@@ -13,18 +13,18 @@
 
 @getBrokersSpreadLevel(percentage: Int) = {
     @percentage match {
-        case i if i > 50 && i<=75 => {warning}
-        case i if i <=  50 => {danger}
+        case i if i > 50 && i <= 75 => {warning}
+        case i if i <= 50 => {danger}
         case i => {}
     }
 }
 
 @getBrokersSkewLevel(percentage: Int) = {
-@percentage match {
-    case i if i > 0 && i<=33 => {warning}
-    case i if i >=  66 => {danger}
-    case i => {}
-}
+    @percentage match {
+        case i if i > 0 && i <= 33 => {warning}
+        case i if i >= 34 => {danger}
+        case i => {}
+    }
 }
 
 @getUnderReplicatedLevel(percentage: Int) = {

--- a/app/views/topic/topicListContent.scala.html
+++ b/app/views/topic/topicListContent.scala.html
@@ -28,11 +28,11 @@
 }
 
 @getUnderReplicatedLevel(percentage: Int) = {
-@percentage match {
-    case i if i > 0 && i<=33 => {warning}
-    case i if i >=  66 => {danger}
-    case i => {}
-}
+    @percentage match {
+        case i if i > 0 && i <= 33 => {warning}
+        case i if i >= 34 => {danger}
+        case i => {}
+    }
 }
 
 @getReassignmentStatus(topic: String) = {


### PR DESCRIPTION
Fix the problem of not being on warning/danger level on topic list when percentage is between 33 and 66.