### PR TITLE
Broker Down bugfix

### DIFF
--- a/app/controllers/ReassignPartitions.scala
+++ b/app/controllers/ReassignPartitions.scala
@@ -15,6 +15,8 @@ import play.api.data.Forms._
 import play.api.data.validation.{Valid, Invalid, Constraint}
 import play.api.mvc._
 
+import scala.collection.mutable
+
 import scala.concurrent.Future
 import scalaz.{\/, \/-, -\/}
 
@@ -162,9 +164,9 @@ object ReassignPartitions extends Controller{
                 brokersViews.flatMap { errorOrBVs =>
                   errorOrBVs.fold (
                   {err: ApiError => Future.successful( Ok(views.html.topic.confirmMultipleAssignments( c, -\/(err) )))},
-                  {bVs: Seq[BVView] => Future {
+                  {bVs => Future {
                     Ok(views.html.topic.manualMultipleAssignments(
-                      c, manualReassignmentForm.fill(flattenedTopicListExtended(topics)), brokers , bVs, manualReassignmentForm.errors
+                      c, flattenedTopicListExtended(topics), brokers , bVs, manualReassignmentForm.errors
                     ))
                   }}
                   )
@@ -203,7 +205,7 @@ object ReassignPartitions extends Controller{
       errors => kafkaManager.getClusterList.map { errorOrClusterList =>
         responseScreen(
           "Manual Reassign Partitions Failure",
-          -\/(IndexedSeq(ApiError("There is something really wrong with your submitted data!")))
+          -\/(IndexedSeq(ApiError("There is something really wrong with your submitted data!\n\n" + errors.toString)))
         )
       },
       assignment => {

--- a/app/kafka/manager/BrokerViewCacheActor.scala
+++ b/app/kafka/manager/BrokerViewCacheActor.scala
@@ -97,15 +97,15 @@ class BrokerViewCacheActor(config: BrokerViewCacheActorConfig) extends LongRunni
     }
   }
 
-  private def allBrokerViews(): Seq[BVView] = {
-    var bvs = mutable.MutableList[BVView]()
+  private def allBrokerViews(): mutable.Map[Int, BVView] = {
+    var bvs = mutable.Map[Int, BVView]()
     for (key <- brokerTopicPartitions.keySet.toSeq.sorted) {
       val bv = brokerTopicPartitions.get(key).map { bv => produceBViewWithBrokerClusterState(bv, key) }
       if (bv.isDefined) {
-        bvs += bv.get
+        bvs.put(key, bv.get)
       }
     }
-    bvs.asInstanceOf[Seq[BVView]]
+    bvs
   }
 
   override def processActorRequest(request: ActorRequest): Unit = {

--- a/app/kafka/manager/KafkaManager.scala
+++ b/app/kafka/manager/KafkaManager.scala
@@ -464,7 +464,7 @@ class KafkaManager(akkaConfig: Config)
     }
   }
 
-  def getBrokersView(clusterName: String): Future[\/[ApiError, Seq[BVView]]] = {
+  def getBrokersView(clusterName: String): Future[\/[ApiError, mutable.Map[Int, BVView]]] = {
     implicit val ec = apiExecutionContext
 
     tryWithKafkaManagerActor(
@@ -472,7 +472,7 @@ class KafkaManager(akkaConfig: Config)
         clusterName,
         BVGetViews
       )
-    )(identity[Seq[BVView]])
+    )(identity[mutable.Map[Int, BVView]])
   }
 
   def getBrokerView(clusterName: String, brokerId: Int): Future[ApiError \/ BVView] = {

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -52,6 +52,11 @@
             $('.' + selectClass).css("display", display);
         }
     }
+
+    function disableSubmission() {
+        $('[type=submit]').prop('disabled', true);
+        $('[type=submit]').removeAttr('type');
+    }
 </script>
 @scripts
 </body>

--- a/app/views/topic/manualMultipleAssignments.scala.html
+++ b/app/views/topic/manualMultipleAssignments.scala.html
@@ -5,16 +5,17 @@
 
 @import scalaz.{\/}
 @import b3.vertical.fieldConstructor
-@import kafka.manager.ActorModel.{TopicIdentity, BVView}
+@import kafka.manager.ActorModel._
 @import kafka.manager.{BrokerListExtended}
 @import kafka.manager.utils._
 @import helper._
 @import models.form._
+@import scala.collection.mutable
 
 @(cluster: String,
-  assignForm: Form[List[(String, List[(Int,List[Int])])]],
+  assignForm: List[(String, List[(Int,List[Int])])],
   brokers: BrokerListExtended,
-  brokersViews: Seq[BVView],
+  brokersViews: mutable.Map[Int, BVView],
   formErrors: Seq[FormError]
 )
 
@@ -22,12 +23,17 @@
 @views.html.navigation.clusterMenu(cluster,"Topic","Manual Partition Assignments",models.navigation.Menus.clusterMenus(cluster))
 }
 
-@replicaSelection(brokerField: Field) = {
-    <select name="@brokerField.name">
-        @for(idx <- 0 until brokers.list.size) {
-            <option value="@idx" @if(idx == brokerField.value.get.toInt){selected}>Broker @idx</option>
-        }
-    </select>
+@replicaSelection(topicIdx: Int, assignIdx: Int, brokerIndex: Int, brokerId: Int) = {
+    @if(brokers.list.filter({broker => broker.id == brokerId}).size > 0) {
+        <select name="topics[@topicIdx].assignments[@assignIdx].brokers[@brokerIndex]">
+            @brokers.list.map { case broker =>
+            <option value="@broker.id" @if(broker.id == brokerId){selected}>Broker @broker.id</option>
+            }
+        </select>
+    } else {
+        <small style="color:red">Broker Down!</small>
+        <script>window.onload = function() {disableSubmission()}</script>
+    }
 }
 
 @topHeading = {
@@ -60,36 +66,34 @@
 
 @mainBody = {
 <div class="panel-body assignment-pane">
-    @repeat(assignForm("topics")) { partitionAssignment =>
-    <div class="assignment-cell" name='@partitionAssignment("topic").value.get'>
+    @assignForm.zipWithIndex.map { case (partitionAssignment, topicIdx) =>
+    <div class="assignment-cell" name="@partitionAssignment._1">
         <h4>
             <input type="text" class="borderless" style="display:none"
-                   name='@partitionAssignment("topic").name'
-                   value='@partitionAssignment("topic").value.get' readonly/>
-            @partitionAssignment("topic").value.get
+                   name='topics[@topicIdx].topic'
+                   value='@partitionAssignment._1' readonly/>
+            @partitionAssignment._1
         </h4>
-        @repeat(partitionAssignment("assignments")) { assignment =>
-        @if(assignment("partition").value.isDefined) {
-        <div class="partition-cell">
-            <table>
-                @repeatWithIndex(assignment("brokers")) { (broker, index) =>
-                @if(index == 0) {
-                <tr>
-                    <th>Partition
-                        <input type="number" class="borderless"
-                               name='@assignment("partition").name'
-                               value='@assignment("partition").value.get'
-                               readonly>
-                    </th>
-                </tr>
-                }
-                <tr><td>
-                    Replica @index: @replicaSelection(broker)
-                </td></tr>
-                }
-            </table>
-        </div>
-        }
+        @partitionAssignment._2.zipWithIndex.map { case (assignment, assgnIndex) =>
+            <div class="partition-cell">
+                <table>
+                    @assignment._2.zipWithIndex.map { case (broker, brokerIndex) =>
+                        @if(brokerIndex == 0) {
+                        <tr>
+                            <th>Partition
+                                <input type="number" class="borderless"
+                                       name='topics[@topicIdx].assignments[@assgnIndex].partition'
+                                       value='@assignment._1'
+                                       readonly>
+                            </th>
+                        </tr>
+                        }
+                        <tr><td>
+                            Replica @brokerIndex: @replicaSelection(topicIdx, assgnIndex, brokerIndex, broker)
+                        </td></tr>
+                    }
+                </table>
+            </div>
         }
     </div>
     }
@@ -108,12 +112,12 @@
 @brokersInfoPane = {
     <input type="text" placeholder="Type to filter metrics"
            id="selectMetrics" onkeyup="selectBySubname('#selectMetrics', 'metric-row', '')"/>
-    @for(idx <- 0 until brokersViews.size) {
+    @brokersViews.map { case (idx, bv) =>
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h4>Broker @idx</h4>
             </div>
-            @views.html.common.expandedBrokerMetrics(brokersViews(idx).metrics)
+            @views.html.common.expandedBrokerMetrics(bv.metrics)
         </div>
     }
 }


### PR DESCRIPTION
Previously, if a broker any broker was down, the list of brokers in
manual partition assignments would get messed up, even if that broker
had no topics.

For exemple, if you have initially 15 brokers, and at some point you figured you didn't need brokers 0 and 2 anymore: brokers 13 and 14 would be labeled as 0 (in the manual partition assignment page) because the code made the assumption that all brokers would be always online. Not anymore.

This is super important, because assignments could have gone wrong previously!