### PR TITLE
Broker Down bugfix

### DIFF
--- a/app/controllers/ReassignPartitions.scala
+++ b/app/controllers/ReassignPartitions.scala
@@ -17,6 +17,8 @@ import play.api.data.Forms._
 import play.api.data.validation.{Valid, Invalid, Constraint}
 import play.api.mvc._
 
+import scala.collection.mutable
+
 import scala.concurrent.Future
 import scalaz.{\/, \/-, -\/}
 
@@ -204,7 +206,8 @@ object ReassignPartitions extends Controller{
             bl <- blOrError
           } yield {
             Ok(views.html.topic.manualAssignments(
-              c, t, manualReassignmentForm.fill(List(flattenTopicIdentity(ti))), bl, bv, manualReassignmentForm.errors
+              //c, t, manualReassignmentForm.fill(List(flattenTopicIdentity(ti))), bl, bv, manualReassignmentForm.errors
+              c, t, List(flattenTopicIdentity(ti)), bl, bv, manualReassignmentForm.errors
             ))
           }
           errorOrResult.fold(err => {
@@ -227,18 +230,19 @@ object ReassignPartitions extends Controller{
         }, { topics: TopicListExtended =>
           kafkaManager.getBrokerList(c).flatMap { errOrCV =>
             errOrCV.fold(
-            { err: ApiError =>
-              Future.successful(Ok(views.html.topic.confirmMultipleAssignments(c, -\/(err))))
-            }, { brokers: BrokerListExtended => {
-              brokersViews.flatMap { errorOrBVs =>
-                errorOrBVs.fold(
-                { err: ApiError => Future.successful(Ok(views.html.topic.confirmMultipleAssignments(c, -\/(err))))}, { bVs: Seq[BVView] => Future {
-                  Ok(views.html.topic.manualMultipleAssignments(
-                    c, manualReassignmentForm.fill(flattenedTopicListExtended(topics)), brokers, bVs, manualReassignmentForm.errors
-                  ))
-                }
-                }
-                )
+            {err: ApiError =>
+              Future.successful( Ok(views.html.topic.confirmMultipleAssignments( c, -\/(err) )))
+            },
+            { brokers: BrokerListExtended => {
+                brokersViews.flatMap { errorOrBVs =>
+                  errorOrBVs.fold (
+                  {err: ApiError => Future.successful( Ok(views.html.topic.confirmMultipleAssignments( c, -\/(err) )))},
+                  {bVs => Future {
+                    Ok(views.html.topic.manualMultipleAssignments(
+                      c, flattenedTopicListExtended(topics), brokers , bVs, manualReassignmentForm.errors
+                    ))
+                  }}
+                  )
               }
             }
             }
@@ -283,7 +287,7 @@ object ReassignPartitions extends Controller{
         errors => kafkaManager.getClusterList.flatMap { errorOrClusterList =>
           responseScreen(
             "Manual Reassign Partitions Failure",
-            -\/(IndexedSeq(ApiError("There is something really wrong with your submitted data!")))
+            -\/(IndexedSeq(ApiError("There is something really wrong with your submitted data!\n\n" + errors.toString)))
           )
         },
         assignment => {

--- a/app/kafka/manager/BrokerViewCacheActor.scala
+++ b/app/kafka/manager/BrokerViewCacheActor.scala
@@ -106,15 +106,15 @@ class BrokerViewCacheActor(config: BrokerViewCacheActorConfig) extends LongRunni
     }
   }
 
-  private def allBrokerViews(): Seq[BVView] = {
-    var bvs = mutable.MutableList[BVView]()
+  private def allBrokerViews(): Map[Int, BVView] = {
+    var bvs = mutable.Map[Int, BVView]()
     for (key <- brokerTopicPartitions.keySet.toSeq.sorted) {
       val bv = brokerTopicPartitions.get(key).map { bv => produceBViewWithBrokerClusterState(bv, key) }
       if (bv.isDefined) {
-        bvs += bv.get
+        bvs.put(key, bv.get)
       }
     }
-    bvs.asInstanceOf[Seq[BVView]]
+    bvs.toMap
   }
 
   override def processActorRequest(request: ActorRequest): Unit = {

--- a/app/kafka/manager/KafkaManager.scala
+++ b/app/kafka/manager/KafkaManager.scala
@@ -576,7 +576,7 @@ class KafkaManager(akkaConfig: Config)
     }
   }
 
-  def getBrokersView(clusterName: String): Future[\/[ApiError, Seq[BVView]]] = {
+  def getBrokersView(clusterName: String): Future[\/[ApiError, Map[Int, BVView]]] = {
     implicit val ec = apiExecutionContext
 
     tryWithKafkaManagerActor(
@@ -584,7 +584,7 @@ class KafkaManager(akkaConfig: Config)
         clusterName,
         BVGetViews
       )
-    )(identity[Seq[BVView]])
+    )(identity[Map[Int, BVView]])
   }
 
   def getBrokerView(clusterName: String, brokerId: Int): Future[ApiError \/ BVView] = {

--- a/app/kafka/manager/KafkaStateActor.scala
+++ b/app/kafka/manager/KafkaStateActor.scala
@@ -320,8 +320,8 @@ case class OffsetCachePassive(curator: CuratorFramework,
     tpi.map {
       case (p, _) =>
         val ownerPath = "%s/%s/%s/%s/%s".format(ZkUtils.ConsumersPath, consumer, "owners", topic, p)
-        (p, ZkUtils.readDataMaybeNull(curator, ownerPath)._1.getOrElse(""))
-    }
+        (p, ZkUtils.readDataMaybeNull(curator, ownerPath)._1.orNull)
+    }.filter(_._2 != null)
   }
   
   def getConsumedTopicDescription(consumer:String, topic:String) : ConsumedTopicDescription = {

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -52,6 +52,11 @@
             $('.' + selectClass).css("display", display);
         }
     }
+
+    function disableSubmission() {
+        $('[type=submit]').prop('disabled', true);
+        $('[type=submit]').removeAttr('type');
+    }
 </script>
 @scripts
 </body>

--- a/app/views/topic/manualAssignments.scala.html
+++ b/app/views/topic/manualAssignments.scala.html
@@ -5,7 +5,7 @@
 
 @import scalaz.{\/}
 @import b3.vertical.fieldConstructor
-@import kafka.manager.ActorModel.{TopicIdentity, BVView}
+@import kafka.manager.ActorModel._
 @import kafka.manager.{BrokerListExtended}
 @import kafka.manager.utils._
 @import helper._
@@ -13,9 +13,9 @@
 
 @(cluster: String,
   topic: String,
-  assignForm: Form[List[(String, List[(Int,List[Int])])]],
+  assignForm: List[(String, List[(Int,List[Int])])],
   brokers: BrokerListExtended,
-  brokersViews: Seq[BVView],
+  brokersViews: Map[Int, BVView],
   formErrors: Seq[FormError]
 )(implicit af: features.ApplicationFeatures, cf: kafka.manager.features.ClusterFeatures)
 
@@ -23,12 +23,17 @@
 @views.html.navigation.clusterMenu(cluster,"Topic","Manual Partition Assignments",models.navigation.Menus.clusterMenus(cluster))
 }
 
-@replicaSelection(brokerField: Field) = {
-    <select name="@brokerField.name">
-        @for(idx <- 0 until brokers.list.size) {
-            <option value="@idx" @if(idx == brokerField.value.get.toInt){selected}>Broker @idx</option>
-        }
-    </select>
+@replicaSelection(topicIdx: Int, assignIdx: Int, brokerIndex: Int, brokerId: Int) = {
+    @if(brokers.list.filter({broker => broker.id == brokerId}).size > 0) {
+        <select name="topics[@topicIdx].assignments[@assignIdx].brokers[@brokerIndex]">
+            @brokers.list.map { case broker =>
+            <option value="@broker.id" @if(broker.id == brokerId){selected}>Broker @broker.id</option>
+            }
+        </select>
+    } else {
+        <small style="color:red">Broker Down!</small>
+        <script>window.onload = function() {disableSubmission()}</script>
+    }
 }
 
 @topHeading = {
@@ -61,36 +66,34 @@
 
 @mainBody = {
 <div class="panel-body assignment-pane">
-    @repeat(assignForm("topics")) { partitionAssignment =>
-    <div class="assignment-cell" name='@partitionAssignment("topic").value.get'>
+    @assignForm.zipWithIndex.map { case (partitionAssignment, topicIdx) =>
+    <div class="assignment-cell" name="@partitionAssignment._1">
         <h4>
             <input type="text" class="borderless" style="display:none"
-                   name='@partitionAssignment("topic").name'
-                   value='@partitionAssignment("topic").value.get' readonly/>
-            @partitionAssignment("topic").value.get
+                   name='topics[@topicIdx].topic'
+                   value='@partitionAssignment._1' readonly/>
+            @partitionAssignment._1
         </h4>
-        @repeat(partitionAssignment("assignments")) { assignment =>
-        @if(assignment("partition").value.isDefined) {
-        <div class="partition-cell">
-            <table>
-                @repeatWithIndex(assignment("brokers")) { (broker, index) =>
-                @if(index == 0) {
-                <tr>
-                    <th>Partition
-                        <input type="number" class="borderless"
-                               name='@assignment("partition").name'
-                               value='@assignment("partition").value.get'
-                               readonly>
-                    </th>
-                </tr>
-                }
-                <tr><td>
-                    Replica @index: @replicaSelection(broker)
-                </td></tr>
-                }
-            </table>
-        </div>
-        }
+        @partitionAssignment._2.zipWithIndex.map { case (assignment, assgnIndex) =>
+            <div class="partition-cell">
+                <table>
+                    @assignment._2.zipWithIndex.map { case (broker, brokerIndex) =>
+                        @if(brokerIndex == 0) {
+                        <tr>
+                            <th>Partition
+                                <input type="number" class="borderless"
+                                       name='topics[@topicIdx].assignments[@assgnIndex].partition'
+                                       value='@assignment._1'
+                                       readonly>
+                            </th>
+                        </tr>
+                        }
+                        <tr><td>
+                            Replica @brokerIndex: @replicaSelection(topicIdx, assgnIndex, brokerIndex, broker)
+                        </td></tr>
+                    }
+                </table>
+            </div>
         }
     </div>
     }
@@ -109,12 +112,12 @@
 @brokersInfoPane = {
     <input type="text" placeholder="Type to filter metrics"
            id="selectMetrics" onkeyup="selectBySubname('#selectMetrics', 'metric-row', '')"/>
-    @for(idx <- 0 until brokersViews.size) {
+    @brokersViews.map { case (idx, bv) =>
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h4>Broker @idx</h4>
             </div>
-            @views.html.common.expandedBrokerMetrics(brokersViews(idx).metrics)
+            @views.html.common.expandedBrokerMetrics(bv.metrics)
         </div>
     }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@
 name := """kafka-manager"""
 
 /* For packaging purposes, -SNAPSHOT MUST contain a digit */
-version := "1.2.9.9"
+version := "1.2.9.10"
 
 scalaVersion := "2.11.7"
 

--- a/test/kafka/manager/TestKafkaManagerActor.scala
+++ b/test/kafka/manager/TestKafkaManagerActor.scala
@@ -145,7 +145,7 @@ class TestKafkaManagerActor extends CuratorAwareTest {
 
   test("get all broker views") {
     withKafkaManagerActor(KMClusterQueryRequest("dev", BVGetViews)) {
-      result: Seq[BVView] => result.nonEmpty
+      result: Map[Int, BVView] => result.nonEmpty
     }
   }
 


### PR DESCRIPTION
Previously, if a broker any broker was down, the list of brokers in
manual partition assignments would get messed up, even if that broker
had no topics.

This is a rebased version of #119 