### PR TITLE
Add default logging for akka

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,12 +13,14 @@ scalacOptions ++= Seq("-Xlint:-missing-interpolator","-Xfatal-warnings","-deprec
 
 // From https://www.playframework.com/documentation/2.3.x/ProductionDist
 assemblyMergeStrategy in assembly := {
+  case "logger.xml" => MergeStrategy.first
   case "play/core/server/ServerWithStop.class" => MergeStrategy.first
   case other => (assemblyMergeStrategy in assembly).value(other)
 }
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-actor" % "2.3.10",
+  "com.typesafe.akka" %% "akka-actor" % "2.3.14",
+  "com.typesafe.akka" %% "akka-slf4j" % "2.3.14",
   "com.google.code.findbugs" % "jsr305" % "2.0.1",
   "org.webjars" %% "webjars-play" % "2.3.0-2",
   "org.webjars" % "bootstrap" % "3.3.4",
@@ -81,7 +83,3 @@ rpmUrl := Some("https://github.com/yahoo/kafka-manager")
 rpmLicense := Some("Apache")
 
 /* End RPM Settings */
-
-
-
-

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -23,7 +23,7 @@ application.langs="en"
 # global=Global
 
 # Database configuration
-# ~~~~~ 
+# ~~~~~
 # You can declare as many datasources as you want.
 # By convention, the default datasource is named `default`
 #
@@ -66,3 +66,7 @@ pinned-dispatcher.type="PinnedDispatcher"
 pinned-dispatcher.executor="thread-pool-executor"
 application.features=["KMClusterManagerFeature","KMTopicManagerFeature","KMPreferredReplicaElectionFeature","KMReassignPartitionsFeature"]
 
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loglevel = "DEBUG"
+}

--- a/conf/logger.xml
+++ b/conf/logger.xml
@@ -1,0 +1,33 @@
+<configuration>
+
+  <conversionRule conversionWord="coloredLevel" converterClass="play.api.Logger$ColoredLevel" />
+
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${application.home}/logs/application.log</file>
+    <encoder>
+       <pattern>%date - [%level] - from %logger in %thread %n%message%n%xException%n</pattern>
+    </encoder>
+
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>application.%d{yyyy-MM-dd}.log</fileNamePattern>
+      <maxHistory>5</maxHistory>
+    </rollingPolicy>
+  </appender>
+
+  <logger name="play" level="INFO" />
+  <logger name="application" level="DEBUG" />
+
+  <!-- Off these ones as they are annoying, and anyway we manage configuration ourself -->
+  <logger name="com.avaje.ebean.config.PropertyMapLoader" level="OFF" />
+  <logger name="com.avaje.ebeaninternal.server.core.XmlConfigLoader" level="OFF" />
+  <logger name="com.avaje.ebeaninternal.server.lib.BackgroundThread" level="OFF" />
+  <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
+
+  <logger name="akka" level="INFO" />
+  <logger name="kafka" level="INFO" />
+
+  <root level="INFO">
+    <appender-ref ref="FILE" />
+  </root>
+
+</configuration>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,9 +19,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.2")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.0")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.5")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
 

--- a/src/templates/etc-default
+++ b/src/templates/etc-default
@@ -20,7 +20,7 @@
 
 # Setting JAVA_OPTS
 # -----------------
-JAVA_OPTS="-Dpidfile.path=/var/run/${{app_name}}/play.pid -Dconfig.file=/etc/${{app_name}}/application.conf $JAVA_OPTS"
+JAVA_OPTS="-Dpidfile.path=/var/run/${{app_name}}/play.pid -Dconfig.file=/etc/${{app_name}}/application.conf -Dlogger.file=/etc/${{app_name}}/logger.xml $JAVA_OPTS"
 
 # Setting PIDFILE
 # ---------------


### PR DESCRIPTION
Hey there,

thank you for making kafka-manager! It's awesome. 

We deployed that into production last week and then the default configuration spilled our harddrive with log-files.

So I thought it would be good to alter the default configuration to be more logging friendly.

Things which I changed:

* Added a logger.xml file which is used by default now
* Make akka log through play's logging 
* Updating akka to 2.3.14 and include akka-slf4j for logging
* Configure some hopefully sane defaults for the logfile of kafka-manager (daily rotation, with max 5 files)
* Removed the sbt-coffeescript plugin, because coffeescript isnt used in this project