### PR TITLE
fix delete topic incompletion

### DIFF
--- a/app/kafka/manager/KafkaCommandActor.scala
+++ b/app/kafka/manager/KafkaCommandActor.scala
@@ -73,7 +73,6 @@ class KafkaCommandActor(kafkaCommandActorConfig: KafkaCommandActorConfig) extend
             Future {
               KCCommandResult(Try {
                 kafkaCommandActorConfig.adminUtils.deleteTopic(kafkaCommandActorConfig.curator, topic) //this should work in 0.8.2
-                kafkaCommandActorConfig.curator.delete().deletingChildrenIfNeeded().forPath(ZkUtils.getTopicPath(topic))
               })
             }
           }


### PR DESCRIPTION
We don't need to delete the path under `/brokers/topics` when we deleting the topic because kafka will help us to do this, otherwise  the delete process will hung, and the next time we can not create the same topic.