### PR TITLE
Add confirm page for kafka-manager topic delete

### DIFF
--- a/app/controllers/Topic.scala
+++ b/app/controllers/Topic.scala
@@ -44,7 +44,7 @@ class Topic (val messagesApi: MessagesApi, val kafkaManagerContext: KafkaManager
       case Success(_) => Valid
     }
   }
-  
+
   val kafka_0_8_1_1_Default = CreateTopic("",1,1,TopicConfigs.configNames(Kafka_0_8_1_1).map(n => TConfig(n,None)).toList)
   val kafka_0_8_2_0_Default = CreateTopic("",1,1,TopicConfigs.configNames(Kafka_0_8_2_0).map(n => TConfig(n,None)).toList)
   val kafka_0_8_2_1_Default = CreateTopic("",1,1,TopicConfigs.configNames(Kafka_0_8_2_1).map(n => TConfig(n,None)).toList)
@@ -63,7 +63,7 @@ class Topic (val messagesApi: MessagesApi, val kafkaManagerContext: KafkaManager
       )
     )(CreateTopic.apply)(CreateTopic.unapply)
   )
-  
+
   val defaultDeleteForm = Form(
     mapping(
       "topic" -> nonEmptyText.verifying(maxLength(250), validateName)
@@ -194,6 +194,15 @@ class Topic (val messagesApi: MessagesApi, val kafkaManagerContext: KafkaManager
           }
         }
       )
+    }
+  }
+
+  def confirmDeleteTopic(clusterName: String, topic: String) = Action.async {
+    val futureErrorOrTopicIdentity = kafkaManager.getTopicIdentity(clusterName, topic)
+    val futureErrorOrConsumerList = kafkaManager.getConsumersForTopic(clusterName, topic)
+
+    futureErrorOrTopicIdentity.zip(futureErrorOrConsumerList).map {case (errorOrTopicIdentity,errorOrConsumerList) =>
+      Ok(views.html.topic.topicDeleteConfirm(clusterName,topic,errorOrTopicIdentity,errorOrConsumerList))
     }
   }
 

--- a/app/views/topic/topicDeleteConfirm.scala.html
+++ b/app/views/topic/topicDeleteConfirm.scala.html
@@ -1,0 +1,41 @@
+@*
+* Copyright 2016 Yahoo Inc. Licensed under the Apache License, Version 2.0
+* See accompanying LICENSE file.
+*@
+@import b3.vertical.fieldConstructor
+@import scalaz.{\/}
+@(cluster:String,
+  topic: String,
+  errorOrTopicIdentity: kafka.manager.ApiError \/ kafka.manager.model.ActorModel.TopicIdentity,
+  optConsumerList: Option[Iterable[String]]
+)(implicit af: features.ApplicationFeatures, messages: play.api.i18n.Messages, menus: models.navigation.Menus)
+
+@theMenu = {
+    @views.html.navigation.clusterMenu(cluster,"Topic","",menus.clusterMenus(cluster)(
+        errorOrTopicIdentity.toOption.map(_.clusterContext.clusterFeatures).getOrElse(kafka.manager.features.ClusterFeatures.default)))
+}
+
+@main(
+    "Topic Delete Confirm",
+    menu = theMenu,
+    breadcrumbs=views.html.navigation.breadCrumbs(models.navigation.BreadCrumbs.withNamedViewAndCluster("Topic Delete Confirm",cluster,topic))) {
+<div class="col-md-12 un-pad-me">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3><button type="button" class="btn btn-link" onclick="goBack()"><span class="glyphicon glyphicon-arrow-left" aria-hidden="true"></span></button>@topic</h3>
+        </div>
+        <h3>Are you sure you want to delete @topic?</h3></br></br>
+        <div class="row">
+            <div class="col-md-3"><button type="button" class="btn btn-primary btn-block" onclick="goBack()">No</button></div>
+            <div class="col-md-2">
+                @b3.form(routes.Topic.handleDeleteTopic(cluster, topic)) {
+                    <fieldset>
+                        @b3.hidden("topic",topic)
+                        @b3.submit('class -> "btn btn-primary btn-block"){ Delete Topic }
+                    </fieldset>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+}

--- a/app/views/topic/topicViewContent.scala.html
+++ b/app/views/topic/topicViewContent.scala.html
@@ -184,12 +184,7 @@
                 <tr>
                     @if(topicIdentity.clusterContext.clusterFeatures.features(kafka.manager.features.KMDeleteTopicFeature)) {
                     <td>
-                        @b3.form(routes.Topic.handleDeleteTopic(cluster, topic)) {
-                        <fieldset>
-                            @b3.hidden("topic",topic)
-                            @b3.submit('class -> "btn btn-primary btn-block"){ Delete Topic }
-                        </fieldset>
-                        }
+                        <a href="@routes.Topic.confirmDeleteTopic(cluster,topic)" class='btn btn-primary btn-block'>Delete Topic</a>
                     </td>
                     }
                     @features.app(features.KMReassignPartitionsFeature) {

--- a/conf/routes
+++ b/conf/routes
@@ -37,6 +37,7 @@ POST        /clusters                                     controllers.Cluster.ha
 POST        /clusters/:c                                  controllers.Cluster.handleUpdateCluster(c:String)
 GET         /clusters/:c/createTopic                      controllers.Topic.createTopic(c:String)
 POST        /clusters/:c/topics/create                    controllers.Topic.handleCreateTopic(c:String)
+GET         /clusters/:c/topics/:t/confirm_delete         controllers.Topic.confirmDeleteTopic(c:String,t:String)
 POST        /clusters/:c/topics/delete                    controllers.Topic.handleDeleteTopic(c:String,t:String)
 GET         /clusters/:c/topics/:t/addPartitions          controllers.Topic.addPartitions(c:String,t:String)
 POST        /clusters/:c/topics/:t/addPartitions          controllers.Topic.handleAddPartitions(c:String,t:String)


### PR DESCRIPTION
This attempts to resolve: https://github.com/yahoo/kafka-manager/issues/197

When you click on `Delete Topic` you are taken to a page like this:
![image](https://cloud.githubusercontent.com/assets/3281726/13122077/3bd15558-d583-11e5-853c-90a95409b153.png)


This should stop accidental deletion of topics and adds very little extra code. Hitting `Delete Topic` on the new page takes the action of the old `Delete Topic` button