### PR TITLE
Output more information during "./sbt clean dist"

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@
  * See accompanying LICENSE file.
  */
 // Comment to get more information during initialization
-logLevel := Level.Warn
+logLevel := Level.Info
 
 resolvers += Resolver.url(
   "bintray-sbt-plugin-releases",


### PR DESCRIPTION
When I clone the kafka-manager repository and try to build it, sbt hangs at below step and give no more information, 
"[info] Loading project definition from /opt/Development/github_repo/kafka-manager/project"

Try to google it and found similar problem:
http://stackoverflow.com/questions/11373536/play-framework-hangs-on-startup-at-loading-project-definition-from
 sbt wasn't truly hanging, it was just pulling a maven and downloading the Internet.

This pull request is to change the logging level from "Warn" to "Info" to give more information during the sbt build.