### PR TITLE
Add a workaround to build inside a docker container.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ version := "1.3.0.8"
 
 scalaVersion := "2.11.7"
 
-scalacOptions ++= Seq("-Xlint:-missing-interpolator","-Xfatal-warnings","-deprecation","-feature","-language:implicitConversions","-language:postfixOps")
+scalacOptions ++= Seq("-Xlint:-missing-interpolator","-Xfatal-warnings","-deprecation","-feature","-language:implicitConversions","-language:postfixOps","-Xmax-classfile-name","240")
 
 // From https://www.playframework.com/documentation/2.3.x/ProductionDist
 assemblyMergeStrategy in assembly := {


### PR DESCRIPTION
Add a workaround for https://github.com/hseeberger/scala-sbt/issues/3 to build inside a docker container.

Otherwise results in the following error if building inside docker on aufs:
```
[info] Compiling 123 Scala sources and 2 Java sources to /root/kafka-manager/target/scala-2.11/classes...
[error] File name too long
[error] one error found
```