### PR TITLE
modify PIDFILE location

### DIFF
--- a/src/templates/etc-default
+++ b/src/templates/etc-default
@@ -20,8 +20,8 @@
 
 # Setting JAVA_OPTS
 # -----------------
-JAVA_OPTS="-Dpidfile.path=/var/run/${{app_name}}.pid -Dconfig.file=/etc/${{app_name}}/application.conf -Dlogger.file=/etc/${{app_name}}/logger.xml $JAVA_OPTS"
+JAVA_OPTS="-Dpidfile.path=/var/run/${{app_name}}/running.pid -Dconfig.file=/etc/${{app_name}}/application.conf -Dlogger.file=/etc/${{app_name}}/logger.xml $JAVA_OPTS"
 
 # Setting PIDFILE
 # ---------------
-PIDFILE="/var/run/${{app_name}}.pid"
+PIDFILE="/var/run/${{app_name}}/running.pid"


### PR DESCRIPTION
Install Kafka-manager through RPM, to start service will be fail(but the script return OK) using /etc/init.d/kafka-manager.
First, check error message, see below:
java.io.FileNotFoundException: /var/run/kafka-manager.pid (Permission denied)
at java.io.FileOutputStream.open0(Native Method)
at java.io.FileOutputStream.open(FileOutputStream.java:270)
at java.io.FileOutputStream.<init>(FileOutputStream.java:213)
at java.io.FileOutputStream.<init>(FileOutputStream.java:162)
at play.core.server.ProdServerStart$.createPidFile(ProdServerStart.scala:131)
at play.core.server.ProdServerStart$.start(ProdServerStart.scala:45)
at play.core.server.ProdServerStart$.main(ProdServerStart.scala:27)
at play.core.server.ProdServerStart.main(ProdServerStart.scala)

the daemon user have not permission to write file in directory '/var/run'.

Second, it's already to create'/var/run/kafka-manager'in boot script('/etc/init.d/kafka-manager'), but not use it.