### PR TITLE
Adds rpm group

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,5 +85,6 @@ rpmRelease := "1"
 rpmVendor := "yahoo"
 rpmUrl := Some("https://github.com/yahoo/kafka-manager")
 rpmLicense := Some("Apache")
+rpmGroup := Some("kafka-manager")
 
 /* End RPM Settings */


### PR DESCRIPTION
Doing `sbt rpm:packageBin`It throws an error that build failed saying that rpmGroup is not set.
This solves the problem.
```
[error] error: Group field must be present in package: (main package)
[error] error: Package has no %description: kafka-manager-1.3.2.1-1.noarch
[info] Building target platforms: noarch-yahoo-Linux
java.lang.RuntimeException: Unable to run rpmbuild, check output for details. Errorcode 1
	at scala.sys.package$.error(package.scala:27)
	at com.typesafe.sbt.packager.rpm.RpmHelper$$anonfun$buildPackage$1.apply(RpmHelper.scala:86)
	at com.typesafe.sbt.packager.rpm.RpmHelper$$anonfun$buildPackage$1.apply(RpmHelper.scala:71)
	at sbt.IO$.withTemporaryDirectory(IO.scala:291)
	at com.typesafe.sbt.packager.rpm.RpmHelper$.buildPackage(RpmHelper.scala:71)
	at com.typesafe.sbt.packager.rpm.RpmHelper$.buildRpm(RpmHelper.scala:20)
	at com.typesafe.sbt.packager.rpm.RpmPlugin$$anonfun$projectSettings$32.apply(RpmPlugin.scala:108)
	at com.typesafe.sbt.packager.rpm.RpmPlugin$$anonfun$projectSettings$32.apply(RpmPlugin.scala:106)
	at scala.Function3$$anonfun$tupled$1.apply(Function3.scala:35)
	at scala.Function3$$anonfun$tupled$1.apply(Function3.scala:34)
	at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
	at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
	at sbt.std.Transform$$anon$4.work(System.scala:63)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
	at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
	at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
	at sbt.Execute.work(Execute.scala:235)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
	at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
	at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

I put a random groupId, tell me which one fits better ;)