### PR TITLE
Support sorting version of Kafka in selectbox

### DIFF
--- a/app/kafka/manager/model/model.scala
+++ b/app/kafka/manager/model/model.scala
@@ -77,7 +77,7 @@ object KafkaVersion {
     "0.10.2.1" -> Kafka_0_10_2_1
   )
 
-  val formSelectList : IndexedSeq[(String,String)] = supportedVersions.toIndexedSeq.filterNot(_._1.contains("beta")).map(t => (t._1,t._2.toString))
+  val formSelectList : IndexedSeq[(String,String)] = supportedVersions.toIndexedSeq.filterNot(_._1.contains("beta")).map(t => (t._1,t._2.toString)).sortWith((a, b) => sortVersion(a._1, b._1))
 
   def apply(s: String) : KafkaVersion = {
     supportedVersions.get(s) match {
@@ -88,6 +88,20 @@ object KafkaVersion {
 
   def unapply(v: KafkaVersion) : Option[String] = {
     Some(v.toString)
+  }
+
+  private def sortVersion(versionNum: String, kafkaVersion: String): Boolean = {
+    val separator = "\\."
+    val versionNumList = versionNum.split(separator, -1).toList
+    val kafkaVersionList = kafkaVersion.split(separator, -1).toList
+    def compare(a: List[String], b: List[String]): Boolean = a.nonEmpty match {
+      case true if b.nonEmpty =>
+        if (a.head == b.head) compare(a.tail, b.tail) else a.head.toInt < b.head.toInt
+      case true if b.isEmpty => false
+      case false if b.nonEmpty => true
+      case _ => true
+    }
+    compare(versionNumList, kafkaVersionList)
   }
 }
 

--- a/test/kafka/manager/model/KafkaVersionTest.scala
+++ b/test/kafka/manager/model/KafkaVersionTest.scala
@@ -11,8 +11,22 @@ import org.scalatest.FunSuite
   */
 class KafkaVersionTest extends FunSuite {
 
-  test("testFormSelectList") {
-
+  test("Sort formSelectList") {
+    val expected: IndexedSeq[(String,String)] = Vector(
+      ("0.8.1.1","0.8.1.1"),
+      ("0.8.2.0","0.8.2.0"),
+      ("0.8.2.1","0.8.2.1"),
+      ("0.8.2.2","0.8.2.2"),
+      ("0.9.0.0","0.9.0.0"),
+      ("0.9.0.1","0.9.0.1"),
+      ("0.10.0.0","0.10.0.0"),
+      ("0.10.0.1","0.10.0.1"),
+      ("0.10.1.0","0.10.1.0"),
+      ("0.10.1.1","0.10.1.1"),
+      ("0.10.2.0","0.10.2.0"),
+      ("0.10.2.1","0.10.2.1")
+    )
+    assertResult(expected)(KafkaVersion.formSelectList)
   }
 
 }

--- a/test/kafka/manager/model/KafkaVersionTest.scala
+++ b/test/kafka/manager/model/KafkaVersionTest.scala
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2017 Yahoo Inc. Licensed under the Apache License, Version 2.0
+ * See accompanying LICENSE file.
+ */
+package kafka.manager.model
+
+import org.scalatest.FunSuite
+
+/**
+  * @author fuji-151a
+  */
+class KafkaVersionTest extends FunSuite {
+
+  test("testFormSelectList") {
+
+  }
+
+}


### PR DESCRIPTION
#415 I supported sorting version of Kafka in selectbox. 
When you update/add a cluster, sorted version is displayed in the selectbox.

Please check this pull request.
Thanks.