### PR TITLE
Add config option for 0.11.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Broker View
 Requirements
 ------------
 
-1. [Kafka 0.8.*.* or 0.9.*.* or 0.10.*.*](http://kafka.apache.org/downloads.html)
+1. [Kafka 0.8.*.* or 0.9.*.* or 0.10.*.* or 0.11.*.*](http://kafka.apache.org/downloads.html)
 2. Java 8+
 
 Configuration

--- a/app/controllers/Logkafka.scala
+++ b/app/controllers/Logkafka.scala
@@ -78,6 +78,8 @@ class Logkafka (val messagesApi: MessagesApi, val kafkaManagerContext: KafkaMana
     LogkafkaNewConfigs.configMaps(Kafka_0_10_2_0).map{case(k,v) => LKConfig(k,Some(v))}.toList)
   val kafka_0_10_2_1_Default = CreateLogkafka("","",
     LogkafkaNewConfigs.configMaps(Kafka_0_10_2_1).map{case(k,v) => LKConfig(k,Some(v))}.toList)
+  val kafka_0_11_0_0_Default = CreateLogkafka("","",
+    LogkafkaNewConfigs.configMaps(Kafka_0_11_0_0).map{case(k,v) => LKConfig(k,Some(v))}.toList)
 
   val defaultCreateForm = Form(
     mapping(
@@ -128,6 +130,7 @@ class Logkafka (val messagesApi: MessagesApi, val kafkaManagerContext: KafkaMana
           case Kafka_0_10_1_1 => (defaultCreateForm.fill(kafka_0_10_1_1_Default), clusterContext)
           case Kafka_0_10_2_0 => (defaultCreateForm.fill(kafka_0_10_2_0_Default), clusterContext)
           case Kafka_0_10_2_1 => (defaultCreateForm.fill(kafka_0_10_2_1_Default), clusterContext)
+          case Kafka_0_11_0_0 => (defaultCreateForm.fill(kafka_0_11_0_0_Default), clusterContext)
         }
       }
     }
@@ -222,6 +225,7 @@ class Logkafka (val messagesApi: MessagesApi, val kafkaManagerContext: KafkaMana
       case Kafka_0_10_1_1 => LogkafkaNewConfigs.configNames(Kafka_0_10_1_1).map(n => (n,LKConfig(n,None))).toMap
       case Kafka_0_10_2_0 => LogkafkaNewConfigs.configNames(Kafka_0_10_2_0).map(n => (n,LKConfig(n,None))).toMap
       case Kafka_0_10_2_1 => LogkafkaNewConfigs.configNames(Kafka_0_10_2_1).map(n => (n,LKConfig(n,None))).toMap
+      case Kafka_0_11_0_0 => LogkafkaNewConfigs.configNames(Kafka_0_11_0_0).map(n => (n,LKConfig(n,None))).toMap
     }
     val identityOption = li.identityMap.get(log_path)
     if (identityOption.isDefined) {

--- a/app/controllers/Topic.scala
+++ b/app/controllers/Topic.scala
@@ -58,6 +58,7 @@ class Topic (val messagesApi: MessagesApi, val kafkaManagerContext: KafkaManager
   val kafka_0_10_1_1_Default = CreateTopic("",1,1,TopicConfigs.configNames(Kafka_0_10_1_1).map(n => TConfig(n,None)).toList)
   val kafka_0_10_2_0_Default = CreateTopic("",1,1,TopicConfigs.configNames(Kafka_0_10_2_0).map(n => TConfig(n,None)).toList)
   val kafka_0_10_2_1_Default = CreateTopic("",1,1,TopicConfigs.configNames(Kafka_0_10_2_1).map(n => TConfig(n,None)).toList)
+  val kafka_0_11_0_0_Default = CreateTopic("",1,1,TopicConfigs.configNames(Kafka_0_11_0_0).map(n => TConfig(n,None)).toList)
 
   val defaultCreateForm = Form(
     mapping(
@@ -148,6 +149,7 @@ class Topic (val messagesApi: MessagesApi, val kafkaManagerContext: KafkaManager
           case Kafka_0_10_1_1 => (defaultCreateForm.fill(kafka_0_10_1_1_Default), clusterContext)
           case Kafka_0_10_2_0 => (defaultCreateForm.fill(kafka_0_10_2_0_Default), clusterContext)
           case Kafka_0_10_2_1 => (defaultCreateForm.fill(kafka_0_10_2_1_Default), clusterContext)
+          case Kafka_0_11_0_0 => (defaultCreateForm.fill(kafka_0_11_0_0_Default), clusterContext)
 
         }
       }
@@ -389,6 +391,7 @@ class Topic (val messagesApi: MessagesApi, val kafkaManagerContext: KafkaManager
           case Kafka_0_10_1_1 => TopicConfigs.configNames(Kafka_0_10_1_1).map(n => (n,TConfig(n,None))).toMap
           case Kafka_0_10_2_0 => TopicConfigs.configNames(Kafka_0_10_2_0).map(n => (n,TConfig(n,None))).toMap
           case Kafka_0_10_2_1 => TopicConfigs.configNames(Kafka_0_10_2_1).map(n => (n,TConfig(n,None))).toMap
+          case Kafka_0_11_0_0 => TopicConfigs.configNames(Kafka_0_11_0_0).map(n => (n,TConfig(n,None))).toMap
         }
         val combinedMap = defaultConfigMap ++ ti.config.toMap.map(tpl => tpl._1 -> TConfig(tpl._1,Option(tpl._2)))
         (defaultUpdateConfigForm.fill(UpdateTopicConfig(ti.topic,combinedMap.toList.map(_._2),ti.configReadVersion)),

--- a/app/kafka/manager/actor/cluster/KafkaStateActor.scala
+++ b/app/kafka/manager/actor/cluster/KafkaStateActor.scala
@@ -154,7 +154,7 @@ class KafkaAdminClient(context: => ActorContext, adminClientActorPath: ActorPath
 
 
 object KafkaManagedOffsetCache {
-  val supportedVersions: Set[KafkaVersion] = Set(Kafka_0_8_2_0, Kafka_0_8_2_1, Kafka_0_8_2_2, Kafka_0_9_0_0, Kafka_0_9_0_1, Kafka_0_10_0_0, Kafka_0_10_0_1, Kafka_0_10_1_0, Kafka_0_10_1_1, Kafka_0_10_2_0, Kafka_0_10_2_1)
+  val supportedVersions: Set[KafkaVersion] = Set(Kafka_0_8_2_0, Kafka_0_8_2_1, Kafka_0_8_2_2, Kafka_0_9_0_0, Kafka_0_9_0_1, Kafka_0_10_0_0, Kafka_0_10_0_1, Kafka_0_10_1_0, Kafka_0_10_1_1, Kafka_0_10_2_0, Kafka_0_10_2_1, Kafka_0_11_0_0)
   val ConsumerOffsetTopic = "__consumer_offsets"
 
   def isSupported(version: KafkaVersion) : Boolean = {

--- a/app/kafka/manager/model/model.scala
+++ b/app/kafka/manager/model/model.scala
@@ -60,6 +60,10 @@ case object Kafka_0_10_2_1 extends KafkaVersion {
   override def toString = "0.10.2.1"
 }
 
+case object Kafka_0_11_0_0 extends KafkaVersion {
+  override def toString = "0.11.0.0"
+}
+
 object KafkaVersion {
   val supportedVersions: Map[String,KafkaVersion] = Map(
     "0.8.1.1" -> Kafka_0_8_1_1,
@@ -74,7 +78,8 @@ object KafkaVersion {
     "0.10.1.0" -> Kafka_0_10_1_0,
     "0.10.1.1" -> Kafka_0_10_1_1,
     "0.10.2.0" -> Kafka_0_10_2_0,
-    "0.10.2.1" -> Kafka_0_10_2_1
+    "0.10.2.1" -> Kafka_0_10_2_1,
+    "0.11.0.0" -> Kafka_0_11_0_0
   )
 
   val formSelectList : IndexedSeq[(String,String)] = supportedVersions.toIndexedSeq.filterNot(_._1.contains("beta")).map(t => (t._1,t._2.toString)).sortWith((a, b) => sortVersion(a._1, b._1))

--- a/app/kafka/manager/utils/LogkafkaNewConfigs.scala
+++ b/app/kafka/manager/utils/LogkafkaNewConfigs.scala
@@ -29,7 +29,8 @@ object LogkafkaNewConfigs {
     Kafka_0_10_1_0 -> logkafka82.LogConfig,
     Kafka_0_10_1_1 -> logkafka82.LogConfig,
     Kafka_0_10_2_0 -> logkafka82.LogConfig,
-    Kafka_0_10_2_1 -> logkafka82.LogConfig
+    Kafka_0_10_2_1 -> logkafka82.LogConfig,
+    Kafka_0_11_0_0 -> logkafka82.LogConfig
     )
 
   def configNames(version: KafkaVersion) : Set[String] = {

--- a/app/kafka/manager/utils/TopicConfigs.scala
+++ b/app/kafka/manager/utils/TopicConfigs.scala
@@ -18,7 +18,7 @@ trait TopicConfigs {
 object TopicConfigs {
   
   val topicConfigsByVersion : Map[KafkaVersion, TopicConfigs] = Map(
-    Kafka_0_8_1_1 -> zero81.LogConfig, 
+    Kafka_0_8_1_1 -> zero81.LogConfig,
     Kafka_0_8_2_0 -> zero82.LogConfig,
     Kafka_0_8_2_1 -> zero82.LogConfig,
     Kafka_0_8_2_2 -> zero82.LogConfig,
@@ -29,7 +29,8 @@ object TopicConfigs {
     Kafka_0_10_1_0 -> zero90.LogConfig,
     Kafka_0_10_1_1 -> zero90.LogConfig,
     Kafka_0_10_2_0 -> zero90.LogConfig,
-    Kafka_0_10_2_1 -> zero90.LogConfig
+    Kafka_0_10_2_1 -> zero90.LogConfig,
+    Kafka_0_11_0_0 -> zero90.LogConfig
     )
 
   def configNames(version: KafkaVersion) : Set[String] = {

--- a/test/kafka/manager/model/KafkaVersionTest.scala
+++ b/test/kafka/manager/model/KafkaVersionTest.scala
@@ -24,7 +24,8 @@ class KafkaVersionTest extends FunSuite {
     "0.10.1.0" -> Kafka_0_10_1_0,
     "0.10.1.1" -> Kafka_0_10_1_1,
     "0.10.2.0" -> Kafka_0_10_2_0,
-    "0.10.2.1" -> Kafka_0_10_2_1
+    "0.10.2.1" -> Kafka_0_10_2_1,
+    "0.11.0.0" -> Kafka_0_11_0_0
   )
 
   test("apply method: supported version.") {
@@ -55,7 +56,8 @@ class KafkaVersionTest extends FunSuite {
       ("0.10.1.0","0.10.1.0"),
       ("0.10.1.1","0.10.1.1"),
       ("0.10.2.0","0.10.2.0"),
-      ("0.10.2.1","0.10.2.1")
+      ("0.10.2.1","0.10.2.1"),
+      ("0.11.0.0","0.11.0.0")
     )
     assertResult(expected)(KafkaVersion.formSelectList)
   }

--- a/test/kafka/manager/utils/TestClusterConfig.scala
+++ b/test/kafka/manager/utils/TestClusterConfig.scala
@@ -135,4 +135,12 @@ class TestClusterConfig extends FunSuite with Matchers {
     assert(deserialize.isSuccess === true)
     assert(cc == deserialize.get)
   }
+
+  test("serialize and deserialize 0.11.0.0") {
+    val cc = ClusterConfig("qa", "0.11.0.0", "localhost:2181", jmxEnabled = false, pollConsumers = true, filterConsumers = true, activeOffsetCacheEnabled = true, jmxUser = None, jmxPass = None, jmxSsl = false, tuning = None, securityProtocol = "PLAINTEXT")
+    val serialize: String = ClusterConfig.serialize(cc)
+    val deserialize = ClusterConfig.deserialize(serialize)
+    assert(deserialize.isSuccess === true)
+    assert(cc == deserialize.get)
+  }
 }


### PR DESCRIPTION
Adds config option for Kafka 0.11.0.0. No special handling of anything new, but it seems to run fine.

Fixes #422 