### PR TITLE
set max-classfile-name to 140

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ version := "1.3.3.15"
 
 scalaVersion := "2.11.8"
 
-scalacOptions ++= Seq("-Xlint:-missing-interpolator","-Xfatal-warnings","-deprecation","-feature","-language:implicitConversions","-language:postfixOps","-Xmax-classfile-name","240")
+scalacOptions ++= Seq("-Xlint:-missing-interpolator","-Xfatal-warnings","-deprecation","-feature","-language:implicitConversions","-language:postfixOps","-Xmax-classfile-name","140")
 
 // From https://www.playframework.com/documentation/2.3.x/ProductionDist
 assemblyMergeStrategy in assembly := {


### PR DESCRIPTION
On encrypted hard drive compilation fails as described in: #275
`[error] (...): File name too long
[error] This can happen on some encrypted or legacy file systems.  Please see SI-3623 for more details.`

On my machine `-Xmax-classfile-name` set to 146 or above cause this problem. 
SO: https://stackoverflow.com/questions/28565837/filename-too-long-sbt suggests 78 (or 100 if one use Slick). I have changed it in build.sbt from 240 to 140 to keep this settings relatively high.