### PR TITLE
Changed default container to fluid one, so that the view looks good on larger screens

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -25,7 +25,7 @@
 
 @menu
 
-<div class="container" role="main">
+<div class="container-fluid" role="main">
 @breadcrumbs
 @content
 </div>


### PR DESCRIPTION
The current container cause extra columns to fall outside table, especially in "Topics" screen. The container-fluid takes to whole screen and prevents from that.