### PR TITLE
Added akka.logger-startup-timeout property

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -31,6 +31,7 @@ akka {
   loglevel = "INFO"
 }
 
+akka.logger-startup-timeout = 60s
 
 basicAuthentication.enabled=false
 basicAuthentication.enabled=${?KAFKA_MANAGER_AUTH_ENABLED}


### PR DESCRIPTION
Added `akka.logger-startup-timeout = 60s `property to the `application.conf` in order to deal with the following error which seems to be quite common:
```

[WARN] [03/27/2018 09:41:31.681] [main] [EventStream(akka://kafka-manager-system)] Logger log1-Slf4jLogger did not respond within Timeout(5000 milliseconds) to InitializeLogger(bus)
error while starting up loggers
akka.ConfigurationException: Logger specified in config can't be loaded [akka.event.slf4j.Slf4jLogger] due to [akka.event.Logging$LoggerInitializationException: Logger log1-Slf4jLogger did not respond with LoggerInitialized, sent instead [TIMEOUT]]
	at akka.event.LoggingBus$$anonfun$4$$anonfun$apply$1.applyOrElse(Logging.scala:116)
	at akka.event.LoggingBus$$anonfun$4$$anonfun$apply$1.applyOrElse(Logging.scala:115)
	at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:36)
	at scala.util.Failure$$anonfun$recover$1.apply(Try.scala:216)
	at scala.util.Try$.apply(Try.scala:192)
	at scala.util.Failure.recover(Try.scala:216)
	at akka.event.LoggingBus$$anonfun$4.apply(Logging.scala:115)
	at akka.event.LoggingBus$$anonfun$4.apply(Logging.scala:110)
	at scala.collection.TraversableLike$WithFilter$$anonfun$map$2.apply(TraversableLike.scala:683)
	at scala.collection.Iterator$class.foreach(Iterator.scala:893)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	at scala.collection.TraversableLike$WithFilter.map(TraversableLike.scala:682)
	at akka.event.LoggingBus$class.startDefaultLoggers(Logging.scala:110)
	at akka.event.EventStream.startDefaultLoggers(EventStream.scala:26)
	at akka.actor.LocalActorRefProvider.init(ActorRefProvider.scala:623)
	at akka.actor.ActorSystemImpl.liftedTree2$1(ActorSystem.scala:620)
	at akka.actor.ActorSystemImpl._start$lzycompute(ActorSystem.scala:617)
	at akka.actor.ActorSystemImpl._start(ActorSystem.scala:617)
	at akka.actor.ActorSystemImpl.start(ActorSystem.scala:634)
	at akka.actor.ActorSystem$.apply(ActorSystem.scala:142)
	at akka.actor.ActorSystem$.apply(ActorSystem.scala:119)
	at kafka.manager.KafkaManager.<init>(KafkaManager.scala:116)
	at controllers.KafkaManagerContext.<init>(KafkaManagerContext.scala:19)
	at loader.ApplicationComponents.<init>(KafkaManagerLoader.scala:32)
	at loader.KafkaManagerLoader.load(KafkaManagerLoader.scala:25)
	at play.core.server.ProdServerStart$.start(ProdServerStart.scala:52)
	at play.core.server.ProdServerStart$.main(ProdServerStart.scala:27)
	at play.core.server.ProdServerStart.main(ProdServerStart.scala)
Caused by: akka.event.Logging$LoggerInitializationException: Logger log1-Slf4jLogger did not respond with LoggerInitialized, sent instead [TIMEOUT]
	at akka.event.LoggingBus$class.akka$event$LoggingBus$$addLogger(Logging.scala:185)
	at akka.event.LoggingBus$$anonfun$4$$anonfun$apply$4.apply(Logging.scala:114)
	at akka.event.LoggingBus$$anonfun$4$$anonfun$apply$4.apply(Logging.scala:113)
	at scala.util.Success$$anonfun$map$1.apply(Try.scala:237)
	at scala.util.Try$.apply(Try.scala:192)
	at scala.util.Success.map(Try.scala:237)
	at akka.event.LoggingBus$$anonfun$4.apply(Logging.scala:113)
	... 23 more
Oops, cannot start the server.
akka.ConfigurationException: Could not start logger due to [akka.ConfigurationException: Logger specified in config can't be loaded [akka.event.slf4j.Slf4jLogger] due to [akka.event.Logging$LoggerInitializationException: Logger log1-Slf4jLogger did not respond with LoggerInitialized, sent instead [TIMEOUT]]]
	at akka.event.LoggingBus$class.startDefaultLoggers(Logging.scala:144)
	at akka.event.EventStream.startDefaultLoggers(EventStream.scala:26)
	at akka.actor.LocalActorRefProvider.init(ActorRefProvider.scala:623)
	at akka.actor.ActorSystemImpl.liftedTree2$1(ActorSystem.scala:620)
	at akka.actor.ActorSystemImpl._start$lzycompute(ActorSystem.scala:617)
	at akka.actor.ActorSystemImpl._start(ActorSystem.scala:617)
	at akka.actor.ActorSystemImpl.start(ActorSystem.scala:634)
	at akka.actor.ActorSystem$.apply(ActorSystem.scala:142)
	at akka.actor.ActorSystem$.apply(ActorSystem.scala:119)
	at kafka.manager.KafkaManager.<init>(KafkaManager.scala:116)
	at controllers.KafkaManagerContext.<init>(KafkaManagerContext.scala:19)
	at loader.ApplicationComponents.<init>(KafkaManagerLoader.scala:32)
	at loader.KafkaManagerLoader.load(KafkaManagerLoader.scala:25)
	at play.core.server.ProdServerStart$.start(ProdServerStart.scala:52)
	at play.core.server.ProdServerStart$.main(ProdServerStart.scala:27)
	at play.core.server.ProdServerStart.main(ProdServerStart.scala)
```