### PR TITLE
Feature/dockerization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,6 +85,15 @@ dockerfile in docker := {
   }
 }
 
+imageNames in docker := Seq(
+  ImageName(
+    s"${name.value}:${version.value}"
+  )
+)
+
+buildOptions in docker := BuildOptions(
+  pullBaseImage = BuildOptions.Pull.Always
+)
 
 /*
  * Start service as user root

--- a/build.sbt
+++ b/build.sbt
@@ -67,6 +67,25 @@ enablePlugins(SbtNativePackager)
 
 enablePlugins(SystemdPlugin)
 
+
+enablePlugins(sbtdocker.DockerPlugin)
+dockerfile in docker := {
+  val zipFile: File = dist.value
+
+  new Dockerfile {
+    from("openjdk:8-jre")
+    add(zipFile, file("/opt/kafka-manager.zip"))
+    workDir("/opt")
+    run("unzip", "kafka-manager.zip")
+    run("rm", "-f", "kafka-manager.zip")
+
+    expose(9000)
+
+    cmd(s"kafka-manager-${version.value}/bin/kafka-manager")
+  }
+}
+
+
 /*
  * Start service as user root
  */

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -38,3 +38,5 @@ resolvers += Classpaths.sbtPluginReleases
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")


### PR DESCRIPTION
by running `sbt docker`, you will get a docker image `kafka-manager:<version>` locally. 
then by running `docker run -d -e<ENV VARS> kafka-manager:<version>`, you will have a running kafka-manager instance listening to port 9000.
port could be mapped to any other port with `-p<any port>:9000` in docker run option. 