### PR TITLE
Remove zookeeper info when cluster-manager feature absent

### DIFF
--- a/app/views/cluster/clusterViewContent.scala.html
+++ b/app/views/cluster/clusterViewContent.scala.html
@@ -2,15 +2,18 @@
 * Copyright 2015 Yahoo Inc. Licensed under the Apache License, Version 2.0
 * See accompanying LICENSE file.
 *@
-@(cluster: String, clusterView: kafka.manager.model.ActorModel.CMView)(implicit messages: play.api.i18n.Messages)
+@(cluster: String, clusterView: kafka.manager.model.ActorModel.CMView
+)(implicit af: features.ApplicationFeatures, messages: play.api.i18n.Messages)
 
 <div class="panel panel-default">
     <div class="panel-heading"><h3>Cluster Information</h3></div>
     <table class="table">
         <tbody>
+        @features.app(features.KMClusterManagerFeature) {
         <tr>
             <td><b>Zookeepers</b></td><td>@clusterView.clusterContext.config.curatorConfig.zkConnect.replace(","," ")</td>
         </tr>
+        }
         <tr>
             <td><b>Version</b></td><td>@clusterView.clusterContext.config.version.toString</td>
         </tr>


### PR DESCRIPTION
When operating Kafka-manager for multiple tenants, its not uncommon to remove the `KMClusterManagerFeature` feature in order to make Kafka-manager read-only and hide details about the setup. I'd suggest that this also includes the ZooKeeper-connect information. However, the ZooKeeper ensemble is _always_ displayed in the Cluster info, alongside the current Kafka version.

This PR removes the ZooKeeper-connect information when `KMClusterManagerFeature` is absent.