### PR TITLE
Add Group Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ LDAP support is through the basic authentication filter.
 - basicAuthentication.ldap.password=< LDAP search password>
 - basicAuthentication.ldap.search-base-dn=< LDAP search base>
 - basicAuthentication.ldap.search-filter=< LDAP search filter>
+- basicAuthentication.ldap.group-filter=< LDAP group filter>
 - basicAuthentication.ldap.connection-pool-size=< number of connection to LDAP server>
 - basicAuthentication.ldap.ssl=< Boolean flag to enable/disable LDAPS>
 
@@ -153,6 +154,7 @@ LDAP support is through the basic authentication filter.
 - basicAuthentication.ldap.password="password"
 - basicAuthentication.ldap.search-base-dn="dc=example,dc=com"
 - basicAuthentication.ldap.search-filter="(uid=$capturedLogin$)"
+- basicAuthentication.ldap.group-filter="cn=allowed-group,ou=groups,dc=example,dc=com"
 - basicAuthentication.ldap.connection-pool-size=10
 - basicAuthentication.ldap.ssl=false
 

--- a/README.md
+++ b/README.md
@@ -141,9 +141,11 @@ LDAP support is through the basic authentication filter.
 - basicAuthentication.ldap.password=< LDAP search password>
 - basicAuthentication.ldap.search-base-dn=< LDAP search base>
 - basicAuthentication.ldap.search-filter=< LDAP search filter>
-- basicAuthentication.ldap.group-filter=< LDAP group filter>
 - basicAuthentication.ldap.connection-pool-size=< number of connection to LDAP server>
 - basicAuthentication.ldap.ssl=< Boolean flag to enable/disable LDAPS>
+
+4. (Optional) Limit access to a specific LDAP Group
+- basicAuthentication.ldap.group-filter=< LDAP group filter>
 
 #### Example (Online LDAP Test Server):
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -51,6 +51,8 @@ basicAuthentication.ldap.search-base-dn=""
 basicAuthentication.ldap.search-base-dn=${?KAFKA_MANAGER_LDAP_SEARCH_BASE_DN}
 basicAuthentication.ldap.search-filter="(uid=$capturedLogin$)"
 basicAuthentication.ldap.search-filter=${?KAFKA_MANAGER_LDAP_SEARCH_FILTER}
+basicAuthentication.ldap.group-filter=""
+basicAuthentication.ldap.group-filter=${?KAFKA_MANAGER_LDAP_GROUP_FILTER}
 basicAuthentication.ldap.connection-pool-size=10
 basicAuthentication.ldap.connection-pool-size=${?KAFKA_MANAGER_LDAP_CONNECTION_POOL_SIZE}
 basicAuthentication.ldap.ssl=false


### PR DESCRIPTION
This PR adds the capability to limit access to members of a defined LDAP or AD Group.
If the config key is empty, access is not limited.