### PR TITLE
A random number of zkhost may cause kafka-manager stop working

### DIFF
--- a/app/kafka/manager/model/model.scala
+++ b/app/kafka/manager/model/model.scala
@@ -175,6 +175,7 @@ object ClusterConfig {
 
   def validateZkHosts(zkHosts: String): Unit = {
     require(zkHosts.length > 0, "cluster zk hosts is illegal, can't be empty!")
+    require(zkHosts.contains(":"), "cluster zk hosts is illegal, should contain colon!")
   }
 
   def apply(name: String


### PR DESCRIPTION
If set the zkhost as a random number when add a kafka cluster on kafka-manager, the server will keep increasing the file handles and finally it can not work well. So i think it is better to add a check for colon.