### PR TITLE
Add Secondary Sort by partition ID for assignment view

### DIFF
--- a/app/views/reassignPartitions.scala.html
+++ b/app/views/reassignPartitions.scala.html
@@ -47,7 +47,7 @@
             <tr><th>Topic</th><th>Partition</th><th>Replica Assignment</th></tr>
             </thead>
             <tbody>
-            @for((kafka.common.TopicAndPartition(topic,partNum),assignment) <- repar.partitionsToBeReassigned.toList.sortBy(_._1.topic) ) {
+            @for((kafka.common.TopicAndPartition(topic,partNum),assignment) <- repar.partitionsToBeReassigned.toList.sortBy(partition => (partition._1.topic, partition._1.partition))) {
             <tr>
                 <td><a href="@routes.Topic.topic(cluster,topic)">@topic</a></td>
                 <td>@partNum</td>


### PR DESCRIPTION
For the `Request Data` section in the `/clusters/$CLUSTER_NAME/assignment` page, this change make it so it also sorts by the partition ID after sorting by topic:

<img width="869" alt="Reassign_Partitions" src="https://user-images.githubusercontent.com/165785/62743467-5247ab00-b9f7-11e9-8103-6fa0b36f5b8a.png">

We have it running on our staging env

<img width="728" alt="Reassign_Partitions" src="https://user-images.githubusercontent.com/165785/62797103-b0c06800-ba8f-11e9-92d2-138f79d1e2f5.png">

---

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
