### PR TITLE
Re-adding unzip to Docker via apt-get; changing Travis build to use OpenJDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 sudo: true
-jdk: oraclejdk8
+jdk: openjdk8
 install: true
 script: travis_wait 30 ./sbt clean coverage assembly
 scala:

--- a/build.sbt
+++ b/build.sbt
@@ -79,6 +79,7 @@ dockerfile in docker := {
 
   new Dockerfile {
     from("openjdk:8-jre-slim")
+    runRaw("apt-get update && apt-get install -y --no-install-recommends unzip")
     add(zipFile, file("/opt/kafka-manager.zip"))
     workDir("/opt")
     run("unzip", "kafka-manager.zip")


### PR DESCRIPTION
An update to `openjdk:8-jre-slim` earlier this year ( docker-library/openjdk#322 ) removed the `unzip` package in the base image, which the current generated dockerfile relies on. 

No associated issues were found, but ran into this while building a fresh docker image locally, and could prevent future updates from getting to the Docker Repo.

---

Since the Travis CI migration from [Trusty to Xenial](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment), oraljdk8 is no longer supported. Updating the travis jdk config to use `openjdk8` instead ([Travis CI issue thread](https://travis-ci.community/t/install-of-oracle-jdk8-is-failing/4365/3)).